### PR TITLE
Disable left and right column from payment page. Fix QR code overlapping

### DIFF
--- a/controllers/front/validation.php
+++ b/controllers/front/validation.php
@@ -44,6 +44,7 @@ class BlockonomicsValidationModuleFrontController extends ModuleFrontController
     public function postProcess()
     {
         $this->display_column_left = false;
+        $this->display_column_right = false;
         $cart = $this->context->cart;
         $blockonomics = $this->module;
 

--- a/views/css/style.css
+++ b/views/css/style.css
@@ -16,15 +16,14 @@
   float:right;
 }
 
-
-
 @media (max-width: 979px) {
   .invoice {
     width:100%;
   }
 }
 
-
+body#module-blockonomics-validation #center_column {width:951px}
+body#module-blockonomics-validation #right_column, body#module-blockonomics-validation #left_column {display:none}
 
 [ng\:cloak], [ng-cloak], [data-ng-cloak], [x-ng-cloak], .ng-cloak, .x-ng-cloak {
   display: none !important;

--- a/views/css/style.css
+++ b/views/css/style.css
@@ -23,7 +23,6 @@
 }
 
 body#module-blockonomics-validation #center_column {width:951px}
-body#module-blockonomics-validation #right_column, body#module-blockonomics-validation #left_column {display:none}
 
 [ng\:cloak], [ng-cloak], [data-ng-cloak], [x-ng-cloak], .ng-cloak, .x-ng-cloak {
   display: none !important;


### PR DESCRIPTION
#35 

By disabling left and right columns the QR code now has the space needed to be disabled correctly  [as shwon here](https://screenshots.firefox.com/dkeAk4iy1NtYiSwO/localhost)