### PR TITLE
Fixes for validator

### DIFF
--- a/blockonomics.php
+++ b/blockonomics.php
@@ -211,23 +211,27 @@ class Blockonomics extends PaymentModule
 
     public function getNewAddress()
     {
-        $options = array(
-            'http' => array(
-                'header'  => array('Authorization: Bearer '.Configuration::get('BLOCKONOMICS_API_KEY'),'Content-type: application/x-www-form-urlencoded'),
-                'method'  => 'POST',
-                'content' => '',
-                'ignore_errors' => true
-            )
-        );
+        $url = Configuration::get('BLOCKONOMICS_NEW_ADDRESS_URL')."?match_callback=".Configuration::get('BLOCKONOMICS_CALLBACK_SECRET');
 
-        //Generate new address for this invoice
-        $context = stream_context_create($options);
-        $contents = file_get_contents(Configuration::get('BLOCKONOMICS_NEW_ADDRESS_URL')."?match_callback=".Configuration::get('BLOCKONOMICS_CALLBACK_SECRET'), false, $context);
-        $responseObj = Tools::jsonDecode($contents);
-        
-        //Create response object if it does not exist
-        if (!isset($responseObj)) $responseObj = new stdClass();
-        $responseObj->{'response_code'} = $http_response_header[0];
+        $ch = curl_init();
+        curl_setopt($ch, CURLOPT_URL, $url);
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
+        curl_setopt($ch, CURLOPT_POST, 1);
+        curl_setopt($ch, CURLOPT_TIMEOUT, 60);
+        curl_setopt($ch, CURLOPT_HTTPHEADER, array(
+            'Authorization: Bearer '.Configuration::get('BLOCKONOMICS_API_KEY'),
+            'Content-type: application/x-www-form-urlencoded'
+            ));
+
+        $data = curl_exec($ch);
+        $httpcode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+        curl_close($ch);
+
+        $responseObj = Tools::jsonDecode($data);
+        if (!isset($responseObj)) {
+            $responseObj = new stdClass();
+        }
+        $responseObj->{'response_code'} = $httpcode;
 
         return $responseObj;
     }
@@ -320,7 +324,7 @@ class Blockonomics extends PaymentModule
         } elseif (Tools::getValue('updateSettings')) {
             Configuration::updateValue('BLOCKONOMICS_API_KEY', Tools::getValue('apiKey'));
             $accept_altcoins = false;
-            if(Tools::getValue('altcoins') == 'altcoins') {
+            if (Tools::getValue('altcoins') == 'altcoins') {
                 $accept_altcoins = true;
             }
 
@@ -328,7 +332,7 @@ class Blockonomics extends PaymentModule
         }
 
         $altcoins_checked = '';
-        if(Configuration::get('BLOCKONOMICS_ACCEPT_ALTCOINS')) {
+        if (Configuration::get('BLOCKONOMICS_ACCEPT_ALTCOINS')) {
             $altcoins_checked = 'checked';
         }
 

--- a/controllers/front/validation.php
+++ b/controllers/front/validation.php
@@ -125,8 +125,8 @@ class BlockonomicsValidationModuleFrontController extends ModuleFrontController
         //Tools::redirectLink(Tools::getHttpHost(true, true) . __PS_BASE_URI__ .'index.php?controller=order-confirmation?id_cart='.(int)($cart->id).'&id_module='.(int)($blockonomics->id).'&id_order='.$blockonomics->currentOrder.'&key='.$customer->secure_key);
     }
 
-    private function displayError($error_str, $blockonomics) {
-
+    private function displayError($error_str, $blockonomics)
+    {
         $unable_to_generate = '<h4>'.$blockonomics->l('Unable to generate bitcoin address.', 'validation').'</h4><p>'.$blockonomics->l('Note for site webmaster: ', 'validation');
         
         $troubleshooting_guide = '</p><p>'.$blockonomics->l('If problem persists, please consult ', 'validation').'<a href="https://blockonomics.freshdesk.com/support/solutions/articles/33000215104-troubleshooting-unable-to-generate-new-address" target="_blank">'.$blockonomics->l('this troubleshooting article', 'validation').'</a></p>';
@@ -137,32 +137,20 @@ class BlockonomicsValidationModuleFrontController extends ModuleFrontController
         die();
     }
 
-    private function checkForErrors($responseObj, $blockonomics) {
-
-        if(!ini_get('allow_url_fopen')) {
-            $error_str = $blockonomics->l('The allow_url_fopen is not enabled, please enable this option to allow address generation.', 'validation');
-
-        } elseif(!isset($responseObj->response_code)) {
+    private function checkForErrors($responseObj, $blockonomics)
+    {
+        if (!isset($responseObj->response_code)) {
             $error_str = $blockonomics->l('Your webhost is blocking outgoing HTTPS connections. Blockonomics requires an outgoing HTTPS POST (port 443) to generate new address. Check with your webhosting provider to allow this.', 'validation');
-
         } else {
-
             switch ($responseObj->response_code) {
-
-                case 'HTTP/1.1 200 OK':
+                case 200:
                     break;
-
-                case 'HTTP/1.1 401 Unauthorized': {
+                case 401:
                     $error_str = $blockonomics->l('API Key is incorrect. Make sure that the API key set in admin Blockonomics module configuration is correct.', 'validation');
                     break;
-                }
-
-                case 'HTTP/1.1 500 Internal Server Error': {
-
-                    if(isset($responseObj->message)) {
-
+                case 500:
+                    if (isset($responseObj->message)) {
                         $error_code = $responseObj->message;
-
                         switch ($error_code) {
                             case "Could not find matching xpub":
                                 $error_str = $blockonomics->l('There is a problem in the Callback URL. Make sure that you have set your Callback URL from the admin Blockonomics module configuration to your Merchants > Settings.', 'validation');
@@ -178,15 +166,14 @@ class BlockonomicsValidationModuleFrontController extends ModuleFrontController
                         $error_str = $responseObj->response_code;
                         break;
                     }
-                }
-
+                    //no break here as if/else handles that
                 default:
-                    $error_str = $responseObj->response_code;
+                    $error_str = 'HTTP Status code: '.$responseObj->response_code;
                     break;
             }
         }
 
-        if(isset($error_str)) {
+        if (isset($error_str)) {
             $this->displayError($error_str, $blockonomics);
         }
     }


### PR DESCRIPTION
It is impossible to get `$http_response_header` from `Tools::file_get_contents` as it is created inside local scope and the `Tools` version of `file_get_contents` does not provide a way to access that. For that reason it had to be changed to cURL. It does the same exact thing, so very little had to be changed.

CURL does not require fopen so the check for that could be removed.

Also formatting and intending fixes for validator.

All switch cases tested on Prestashop 1.6 and 1.7