### PR TITLE
Fix varchar 255, issue #69

### DIFF
--- a/blockonomics.php
+++ b/blockonomics.php
@@ -33,7 +33,7 @@ class Blockonomics extends PaymentModule
     {
         $this->name = 'blockonomics';
         $this->tab = 'payments_gateways';
-        $this->version = '1.7.8';
+        $this->version = '1.7.9';
         $this->author = 'Blockonomics';
         $this->need_instance = 1;
         $this->bootstrap = true;
@@ -185,13 +185,13 @@ class Blockonomics extends PaymentModule
             id INT UNSIGNED NOT NULL AUTO_INCREMENT,
             id_order INT UNSIGNED NOT NULL,
             timestamp INT(8) NOT NULL,
-            addr varchar(255) NOT NULL,
-            txid varchar(255) NOT NULL,
+            addr varchar(191) NOT NULL,
+            txid varchar(191) NOT NULL,
             status int(8) NOT NULL,
             value double(10,2) NOT NULL,
             bits int(8) NOT NULL,
             bits_payed int(8) NOT NULL,
-            uuid varchar(255) NOT NULL,
+            uuid varchar(191) NOT NULL,
             PRIMARY KEY (id),
         UNIQUE KEY order_table (addr))"
         );

--- a/upgrade/install-1.7.9.php
+++ b/upgrade/install-1.7.9.php
@@ -1,0 +1,49 @@
+<?php
+/**
+* 2011-2016 Blockonomics
+*
+* NOTICE OF LICENSE
+*
+* This source file is subject to the Academic Free License (AFL 3.0)
+* that is bundled with this package in the file LICENSE.txt.
+* It is also available through the world-wide-web at this URL:
+* http://opensource.org/licenses/afl-3.0.php
+* If you did not receive a copy of the license and are unable to
+* obtain it through the world-wide-web, please send an email
+* to license@blockonomics.co so we can send you a copy immediately.
+*
+* @author    Blockonomics Admin <admin@blockonomics.co>
+* @copyright 2011-2016 Blockonomics
+* @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+* International Registered Trademark & Property of Blockonomics
+*/
+
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
+
+function upgrade_module_1_7_9($object, $install = false)
+{
+    $object = $object;
+    $install = $install;
+    updateDatabase();
+    return true; //if there were no errors
+}
+
+//function used to upgrade the module table
+function updateDatabase()
+{
+    $query = 'ALTER TABLE `'._DB_PREFIX_.'blockonomics_bitcoin_orders'.'` MODIFY `addr` varchar(191) NOT NULL';
+    if (!Db::getInstance()->execute($query)) {
+        return false;
+    }
+    $query = 'ALTER TABLE `'._DB_PREFIX_.'blockonomics_bitcoin_orders'.'` MODIFY `uuid` varchar(191) NOT NULL';
+    if (!Db::getInstance()->execute($query)) {
+        return false;
+    }
+    $query = 'ALTER TABLE `'._DB_PREFIX_.'blockonomics_bitcoin_orders'.'` MODIFY `txid` varchar(191) NOT NULL';
+    if (!Db::getInstance()->execute($query)) {
+        return false;
+    }
+    return true;
+}


### PR DESCRIPTION
Fix varchar 255, issue #69

InnoDB has a maximum index length of 767 bytes, so with utf8mb4 you can only store **191 characters**.
Bech32 string is at most **90 characters**.

Decreased `varchar(255)` to max allowable `varchar(191)`.
Alters database for upgrading users.