### PR TITLE
Removing custom status and adding txid to payment details

### DIFF
--- a/blockonomics.php
+++ b/blockonomics.php
@@ -33,7 +33,7 @@ class Blockonomics extends PaymentModule
     {
         $this->name = 'blockonomics';
         $this->tab = 'payments_gateways';
-        $this->version = '1.7.9.2';
+        $this->version = '1.8.1';
         $this->author = 'Blockonomics';
         $this->need_instance = 1;
         $this->bootstrap = true;

--- a/blockonomics.php
+++ b/blockonomics.php
@@ -33,7 +33,7 @@ class Blockonomics extends PaymentModule
     {
         $this->name = 'blockonomics';
         $this->tab = 'payments_gateways';
-        $this->version = '1.8.0';
+        $this->version = '1.7.9.2';
         $this->author = 'Blockonomics';
         $this->need_instance = 1;
         $this->bootstrap = true;
@@ -449,7 +449,7 @@ class Blockonomics extends PaymentModule
         if (!Configuration::get('BLOCKONOMICS_API_KEY')) {
             $output =
                 $output .
-                $this->display(__FILE__, 'views/templates/admin/backend.tpl');
+                $this->display(__FILE__, '/views/templates/admin/backend.tpl');
         }
 
         return $output . $this->displayForm();

--- a/blockonomics.php
+++ b/blockonomics.php
@@ -449,7 +449,7 @@ class Blockonomics extends PaymentModule
         if (!Configuration::get('BLOCKONOMICS_API_KEY')) {
             $output =
                 $output .
-                $this->display(__FILE__, '/views/templates/admin/backend.tpl');
+                $this->display(__FILE__, 'views/templates/admin/backend.tpl');
         }
 
         return $output . $this->displayForm();

--- a/blockonomics.php
+++ b/blockonomics.php
@@ -102,21 +102,6 @@ class Blockonomics extends PaymentModule
     public function install()
     {
         if (!parent::install() or
-            !$this->installOrder(
-                'BLOCKONOMICS_ORDER_STATE_WAIT',
-                'Awaiting Bitcoin Payment',
-                null
-            ) or
-            !$this->installOrder(
-                'BLOCKONOMICS_ORDER_STATUS_0',
-                'Waiting for 2 Confirmations',
-                null
-            ) or
-            !$this->installOrder(
-                'BLOCKONOMICS_ORDER_STATUS_2',
-                'Bitcoin Payment Confirmed',
-                null
-            ) or
             !$this->installDB() or
             !$this->registerHook('paymentOptions') or
             !$this->registerHook('actionValidateOrder')
@@ -131,9 +116,6 @@ class Blockonomics extends PaymentModule
     public function uninstall()
     {
         if (!parent::uninstall() or
-            !$this->uninstallOrder('BLOCKONOMICS_ORDER_STATE_WAIT') or
-            !$this->uninstallOrder('BLOCKONOMICS_ORDER_STATUS_0') or
-            !$this->uninstallOrder('BLOCKONOMICS_ORDER_STATUS_2') or
             !$this->uninstallDB()
         ) {
             return false;

--- a/blockonomics.php
+++ b/blockonomics.php
@@ -33,7 +33,7 @@ class Blockonomics extends PaymentModule
     {
         $this->name = 'blockonomics';
         $this->tab = 'payments_gateways';
-        $this->version = '1.7.10';
+        $this->version = '1.7.91';
         $this->author = 'Blockonomics';
         $this->need_instance = 1;
         $this->bootstrap = true;

--- a/blockonomics.php
+++ b/blockonomics.php
@@ -33,7 +33,7 @@ class Blockonomics extends PaymentModule
     {
         $this->name = 'blockonomics';
         $this->tab = 'payments_gateways';
-        $this->version = '1.8.1';
+        $this->version = '1.7.91';
         $this->author = 'Blockonomics';
         $this->need_instance = 1;
         $this->bootstrap = true;

--- a/blockonomics.php
+++ b/blockonomics.php
@@ -33,7 +33,7 @@ class Blockonomics extends PaymentModule
     {
         $this->name = 'blockonomics';
         $this->tab = 'payments_gateways';
-        $this->version = '1.7.91';
+        $this->version = '1.7.10';
         $this->author = 'Blockonomics';
         $this->need_instance = 1;
         $this->bootstrap = true;
@@ -103,6 +103,7 @@ class Blockonomics extends PaymentModule
     {
         if (!parent::install() or
             !$this->installDB() or
+            !$this->installOrder('BLOCKONOMICS_ORDER_STATE_WAIT', 'Awaiting Bitcoin Payment', null) or
             !$this->registerHook('paymentOptions') or
             !$this->registerHook('actionValidateOrder')
         ) {

--- a/callback.php
+++ b/callback.php
@@ -78,11 +78,7 @@ if ($secret == Configuration::get('BLOCKONOMICS_CALLBACK_SECRET')) {
             //Update order status
             $o = new Order($order[0]['id_order']);
 
-            if ($status == 0 || $status == 1) {
-                $o->setCurrentState(
-                    Configuration::get('PS_OS_PREPARATION')
-                );
-            } elseif ($status == 2) {
+            if ($status == 2) {
                 $id_order = $order[0]['id_order'];
                 $note = getInvoiceNote($order[0]);
                 $sql = "UPDATE " . _DB_PREFIX_ .

--- a/callback.php
+++ b/callback.php
@@ -96,6 +96,7 @@ if ($secret == Configuration::get('BLOCKONOMICS_CALLBACK_SECRET')) {
                     Context::getContext()->currency = new Currency($o->id_currency);
                     $o->setCurrentState(Configuration::get('PS_OS_PAYMENT'));
                 }
+                insertTXIDIntoPaymentDetails($order[0]['txid'], $o->reference);
             }
         } else {
             echo 'Order not found';
@@ -103,6 +104,14 @@ if ($secret == Configuration::get('BLOCKONOMICS_CALLBACK_SECRET')) {
     }
 } else {
     echo 'Secret not matching';
+}
+
+function insertTXIDIntoPaymentDetails($txid, $order_reference)
+{
+    $sql = "UPDATE " . _DB_PREFIX_ .
+    "order_payment SET `transaction_id` = '" . $txid .
+    "' WHERE `order_reference` = '" . $order_reference. "'";
+    Db::getInstance()->Execute($sql);
 }
 
 function getInvoiceNote($order)

--- a/callback.php
+++ b/callback.php
@@ -117,7 +117,6 @@ function insertTXIDIntoPaymentDetails($order, $txid, $bits_payed)
     $len = count($payments);
     $i = 0;
     foreach ($payments as $payment) {
-        $i++;
         //if this txid has already been saved
         if ($payment->transaction_id == $txid) {
             return;
@@ -125,11 +124,13 @@ function insertTXIDIntoPaymentDetails($order, $txid, $bits_payed)
         } else if (!$payment->transaction_id){
             $payment->transaction_id = $txid;
             $payment->save();
+            return;
         //all orders have a transaction_id, but this txid has not been saved 
         } else if ($i == $len - 1) {
             $payment_method = 'Bitcoin - Blockonomics';
-            $order->addOrderPayment($rounded_total, $payment_method, $txid);
+            $order->addOrderPayment($rounded_total, $payment_method, $txid, $currency);
         }
+        $i++;
     }
 }
 

--- a/callback.php
+++ b/callback.php
@@ -108,10 +108,10 @@ function insertTXIDIntoPaymentDetails($presta_order, $txid, $blockonomics_order)
     //Get amount payed in fiat currency
     $currency = new Currency((int) $presta_order->id_currency);
     $btc_price = $blockonomics_order['bits']/$blockonomics_order['value'];
-    $amount = $btc_price * $blockonomics_order['bits_payed'];
+    $amount = $blockonomics_order['bits_payed'] / $btc_price;
 
     $payment_details = $presta_order->getOrderPayments()[0];
-    if (!$payment_details->transaction_id) {
+    if (true) {
         $payment_details->transaction_id = $txid;
         $payment_details->amount = $amount;
         $payment_details->save();

--- a/callback.php
+++ b/callback.php
@@ -111,7 +111,6 @@ function insertTXIDIntoPaymentDetails($order, $txid, $bits_payed)
     $url = Configuration::get('BLOCKONOMICS_PRICE_URL') . $currency->iso_code;
     $price = $blockonomics->doCurlCall($url)->data->price;
     $total = $price * $bits_payed * 1.0e-8;
-    $rounded_total = round($total, 2);
 
     $payments = $order->getOrderPayments();
     $len = count($payments);
@@ -123,12 +122,13 @@ function insertTXIDIntoPaymentDetails($order, $txid, $bits_payed)
         //if the payment does not have a transaction id, save the TXID
         } else if (!$payment->transaction_id){
             $payment->transaction_id = $txid;
+            $payment->amount = $total;
             $payment->save();
             return;
         //all orders have a transaction_id, but this txid has not been saved 
         } else if ($i == $len - 1) {
             $payment_method = 'Bitcoin - Blockonomics';
-            $order->addOrderPayment($rounded_total, $payment_method, $txid, $currency);
+            $order->addOrderPayment($total, $payment_method, $txid, $currency);
         }
         $i++;
     }

--- a/callback.php
+++ b/callback.php
@@ -105,13 +105,11 @@ if ($secret == Configuration::get('BLOCKONOMICS_CALLBACK_SECRET')) {
 
 function insertTXIDIntoPaymentDetails($presta_order, $txid, $blockonomics_order)
 {
-    //Get amount payed in fiat currency
-    $currency = new Currency((int) $presta_order->id_currency);
     $btc_price = $blockonomics_order['bits']/$blockonomics_order['value'];
     $amount = $blockonomics_order['bits_payed'] / $btc_price;
-
+    
     $payment_details = $presta_order->getOrderPayments()[0];
-    if (true) {
+    if (!$payment_details->transaction_id) {
         $payment_details->transaction_id = $txid;
         $payment_details->amount = $amount;
         $payment_details->save();

--- a/callback.php
+++ b/callback.php
@@ -105,14 +105,13 @@ if ($secret == Configuration::get('BLOCKONOMICS_CALLBACK_SECRET')) {
 
 function insertTXIDIntoPaymentDetails($presta_order, $txid, $blockonomics_order)
 {
-    $btc_price = $blockonomics_order['bits']/$blockonomics_order['value'];
-    $amount = $blockonomics_order['bits_payed'] / $btc_price;
+    $paid_ratio = $blockonomics_order['bits_payed'] / $blockonomics_order['bits'];
+    $amount = round($paid_ratio * $blockonomics_order['value'], 2);
     
-    $payment_details = $presta_order->getOrderPayments()[0];
-    if (!$payment_details->transaction_id) {
-        $payment_details->transaction_id = $txid;
-        $payment_details->amount = $amount;
-        $payment_details->save();
+    $payments = $presta_order->getOrderPayments();
+    if (!$payments) {
+        $payment_method = 'Bitcoin - Blockonomics';
+        $presta_order->addOrderPayment($amount, $payment_method, $txid);
     }
 }
 

--- a/callback.php
+++ b/callback.php
@@ -80,7 +80,7 @@ if ($secret == Configuration::get('BLOCKONOMICS_CALLBACK_SECRET')) {
 
             if ($status == 0 || $status == 1) {
                 $o->setCurrentState(
-                    Configuration::get('BLOCKONOMICS_ORDER_STATUS_0')
+                    Configuration::get('PS_OS_PREPARATION')
                 );
             } elseif ($status == 2) {
                 $id_order = $order[0]['id_order'];
@@ -90,9 +90,6 @@ if ($secret == Configuration::get('BLOCKONOMICS_CALLBACK_SECRET')) {
                 "' WHERE `id_order` = " . (int) $id_order;
                 Db::getInstance()->Execute($sql);
 
-                $o->setCurrentState(
-                    Configuration::get('BLOCKONOMICS_ORDER_STATUS_2')
-                );
                 if ($order[0]['bits'] > $order[0]['bits_payed']) {
                     $o->setCurrentState(Configuration::get('PS_OS_ERROR'));
                 } else {

--- a/controllers/front/validation.php
+++ b/controllers/front/validation.php
@@ -145,7 +145,7 @@ class BlockonomicsValidationModuleFrontController extends ModuleFrontController
             $mes = "Adr BTC : " . $address;
             $blockonomics->validateOrder(
                 (int) $cart->id,
-                (int) Configuration::get('PS_OS_PREPARATION'),
+                (int) Configuration::get('BLOCKONOMICS_ORDER_STATE_WAIT'),
                 $total,
                 $blockonomics->displayName,
                 $mes,

--- a/controllers/front/validation.php
+++ b/controllers/front/validation.php
@@ -145,7 +145,7 @@ class BlockonomicsValidationModuleFrontController extends ModuleFrontController
             $mes = "Adr BTC : " . $address;
             $blockonomics->validateOrder(
                 (int) $cart->id,
-                Configuration::get('BLOCKONOMICS_ORDER_STATE_WAIT'),
+                (int) Configuration::get('PS_OS_PREPARATION'),
                 $total,
                 $blockonomics->displayName,
                 $mes,


### PR DESCRIPTION
### Removing custom status
This PR removes the custom order statuses that caused the orders to not load after removing the module. Instead, [statuses](http://doc.prestashop.com/display/PS17/Statuses) native to PrestaShop are being used. My testing shows that this has two consequences that we should be aware of:

1. The orders are confined to only two statuses, whereas before three were being used. These are _Processing in progress_ and _Payment accepted_. At the moment _Processing in progress_ is being used from the order is created during checkout until the payment is fully confirmed. After that the status is set to _Payment accepted_.
2. As a result of using _Processing in progress_ a delivery slip is being generated. The delivery slip is very generic as seen on the example below. It doesn't seem to be of any importance nor harm, just something to be aware of.

![image](https://user-images.githubusercontent.com/36883813/116203193-6658b080-a776-11eb-88c3-c0e490f601eb.png)

### Adding txid to payment details
This PR also introduces the addition of TXID as a part of the Payment _Transaction ID_. This is stored in the PrestaShop database and will remain even if the module is removed.

![image](https://user-images.githubusercontent.com/36883813/116203776-04e51180-a777-11eb-9189-fc550e7b05b4.png)

This PR has been confirmed to be in line with PrestaShop standards according to the _PrestaShop Validator_.