### PR TITLE
Saving both BCH/BTC address even after successful payment

### DIFF
--- a/callback.php
+++ b/callback.php
@@ -101,7 +101,7 @@ function insertTXIDIntoPaymentDetails($presta_order, $txid, $blockonomics_order)
     $paid_ratio = $blockonomics_order['bits_payed'] / $blockonomics_order['bits'];
     $amount = round($paid_ratio * $blockonomics_order['value'], 2);
 
-    $presta_order = new Order($blockonomics_order['id_order']);    
+    $presta_order = new Order($blockonomics_order['id_order']);
     $payments = $presta_order->getOrderPayments();
     if (!$payments) {
         //Too small amount was used in the payment, so the order was not set to PS_OS_PAYMENT and no payment created

--- a/callback.php
+++ b/callback.php
@@ -101,13 +101,7 @@ function insertTXIDIntoPaymentDetails($presta_order, $txid, $blockonomics_order)
     $paid_ratio = $blockonomics_order['bits_payed'] / $blockonomics_order['bits'];
     $amount = round($paid_ratio * $blockonomics_order['value'], 2);
 
-    // Get invoice and save the address used in the successful payment as an invoice note
-    $presta_order = new Order($blockonomics_order['id_order']);
-    $invoice = $presta_order->getInvoicesCollection()[0];
-    $invoice_note = Tools::strtoupper($blockonomics_order['crypto']) . " Address: " . $blockonomics_order['addr'];
-    $invoice->note = $invoice_note;
-    $invoice->save();
-    
+    $presta_order = new Order($blockonomics_order['id_order']);    
     $payments = $presta_order->getOrderPayments();
     if (!$payments) {
         //Too small amount was used in the payment, so the order was not set to PS_OS_PAYMENT and no payment created

--- a/controllers/front/payment.php
+++ b/controllers/front/payment.php
@@ -301,7 +301,7 @@ class BlockonomicsPaymentModuleFrontController extends ModuleFrontController
         $invoice = $presta_order->getInvoicesCollection()[0];
         //Leave a space after $address since html tags don't work and perhaps two addresses will be saved
         $invoice_note = Tools::strtoupper($crypto) . " Address: $address ";
-        $invoice->note = $invoice->note . $invoice_note;
+        $invoice->note = $invoice->note . "\r\n" . $invoice_note;
         $invoice->save();
     }
 


### PR DESCRIPTION
Both BCH/BTC address are now saved in the invoice note, even after a successful payment callback. Also, a new line is added between BTC/BCH address in the invoice note. 