### PR TITLE
Fix for "Unable to generate bitcoin address" error not being shown

### DIFF
--- a/controllers/front/payment.php
+++ b/controllers/front/payment.php
@@ -116,7 +116,7 @@ class BlockonomicsPaymentModuleFrontController extends ModuleFrontController
             $bits = $this->getBits($blockonomics, $crypto['code'], $currency, $total);
             $time_remaining = Configuration::get('BLOCKONOMICS_TIMEPERIOD');
             $responseObj = $blockonomics->getNewAddress($crypto['code']);
-            if (!$responseObj->data || !$responseObj->data->address) {
+            if (!$responseObj->data || !isset($responseObj->data->address)) {
                 $this->displayError($blockonomics);
             }
             $address = $responseObj->data->address;
@@ -204,7 +204,7 @@ class BlockonomicsPaymentModuleFrontController extends ModuleFrontController
             $bits = $this->getBits($blockonomics, $crypto['code'], $currency, $total);
             $time_remaining = Configuration::get('BLOCKONOMICS_TIMEPERIOD');
             $responseObj = $blockonomics->getNewAddress($crypto['code']);
-            if (!$responseObj->data || !$responseObj->data->address) {
+            if (!$responseObj->data || !isset($responseObj->data->address)) {
                 $this->displayError($blockonomics);
             }
             $address = $responseObj->data->address;


### PR DESCRIPTION
Now it shows the message below if an address isn't generated:
![image](https://user-images.githubusercontent.com/36883813/123507821-97862c00-d6a6-11eb-844a-50476e5a5067.png)
