### PR TITLE
Use Tools::Redirect for finalizing order

### DIFF
--- a/controllers/front/payment.php
+++ b/controllers/front/payment.php
@@ -261,7 +261,8 @@ class BlockonomicsPaymentModuleFrontController extends ModuleFrontController
                 'key' => $customer->secure_key,
                 'id_cart' => (int)$cart->id
                 ),
-            true);
+            true
+        );
 
         $base_websocket_url = ($crypto['code']  == 'bch') ?
         BlockonomicsPaymentModuleFrontController::BLOCKONOMICS_BCH_WEBSOCKET_URL :

--- a/controllers/front/payment.php
+++ b/controllers/front/payment.php
@@ -260,8 +260,8 @@ class BlockonomicsPaymentModuleFrontController extends ModuleFrontController
                 'id_order' => $id_order,
                 'key' => $customer->secure_key,
                 'id_cart' => (int)$cart->id
-                )
-            , true);
+                ),
+            true);
 
         $base_websocket_url = ($crypto['code']  == 'bch') ?
         BlockonomicsPaymentModuleFrontController::BLOCKONOMICS_BCH_WEBSOCKET_URL :

--- a/controllers/front/payment.php
+++ b/controllers/front/payment.php
@@ -252,16 +252,16 @@ class BlockonomicsPaymentModuleFrontController extends ModuleFrontController
             }
         }
 
-        $redirect_link = __PS_BASE_URI__ .
-            $this->context->language->iso_code.
-            '/order-confirmation?&id_module=' .
-            (int) $blockonomics->id .
-            '&id_order=' .
-            $id_order .
-            '&key=' .
-            $customer->secure_key .
-            '&id_cart=' .
-            (int) $cart->id;
+        $redirect_link =  $this->context->link->getModuleLink(
+            $blockonomics->name,
+            'redirect',
+            array(
+                'id_module' => (int)$blockonomics->id,
+                'id_order' => $id_order,
+                'key' => $customer->secure_key,
+                'id_cart' => (int)$cart->id
+                )
+            , true);
 
         $base_websocket_url = ($crypto['code']  == 'bch') ?
         BlockonomicsPaymentModuleFrontController::BLOCKONOMICS_BCH_WEBSOCKET_URL :

--- a/controllers/front/redirect.php
+++ b/controllers/front/redirect.php
@@ -23,6 +23,7 @@
  *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
  *  International Registered Trademark & Property of PrestaShop SA
  */
+
 class BlockonomicsRedirectModuleFrontController extends ModuleFrontController
 {
     public function postProcess()
@@ -32,6 +33,14 @@ class BlockonomicsRedirectModuleFrontController extends ModuleFrontController
         $key = Tools::getValue('key');
         $id_cart = Tools::getValue('id_cart');
 
-        Tools::redirect('index.php?controller=order-confirmation&id_cart='.$id_cart.'&id_module='.$id_module.'&id_order='.$id_order.'&key='.$key);
+        Tools::redirect(
+            'index.php?controller=order-confirmation&id_cart='.
+            $id_cart.
+            '&id_module='.
+            $id_module.
+            '&id_order='.
+            $id_order.
+            '&key='.
+            $key);
     }
 }

--- a/controllers/front/redirect.php
+++ b/controllers/front/redirect.php
@@ -41,6 +41,7 @@ class BlockonomicsRedirectModuleFrontController extends ModuleFrontController
             '&id_order='.
             $id_order.
             '&key='.
-            $key);
+            $key
+        );
     }
 }

--- a/controllers/front/redirect.php
+++ b/controllers/front/redirect.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * 2007-2015 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License (AFL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/afl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ *  @author    PrestaShop SA <contact@prestashop.com>
+ *  @copyright 2007-2015 PrestaShop SA
+ *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+ *  International Registered Trademark & Property of PrestaShop SA
+ */
+class BlockonomicsRedirectModuleFrontController extends ModuleFrontController
+{
+    public function postProcess()
+    {
+        $id_module = Tools::getValue('id_module');
+        $id_order = Tools::getValue('id_order');
+        $key = Tools::getValue('key');
+        $id_cart = Tools::getValue('id_cart');
+
+        Tools::redirect('index.php?controller=order-confirmation&id_cart='.$id_cart.'&id_module='.$id_module.'&id_order='.$id_order.'&key='.$key);
+    }
+}


### PR DESCRIPTION
It works, the only thing was that the name finish_order has been changed for redirect. I had some trouble with getting PrestaShop to detect the controller when using more than one words to describe it (camelCase and snake_case). Can do more research into if needed.

This PR accomplishes the points below:
- Created a controller endpoint - redirect.
- JS sends the customer to the redirect controller after payment.
- The redirect controller redirects the user to order confirmation screen using `Tools:redirect()`
