### PR TITLE
Update callback to update invoices using reference number instead of ID

### DIFF
--- a/callback.php
+++ b/callback.php
@@ -79,7 +79,7 @@ if ($secret == Configuration::get('BLOCKONOMICS_CALLBACK_SECRET')) {
             //Update order status
             $o = new Order($order[0]['id_order']);
             $linked_orders = $o->getByReference($o->reference);
-            $new_order_state = NULL;
+            $new_order_state = null;
             
             if ($status == 2) {
                 if ($order[0]['bits'] > $order[0]['bits_payed']) {
@@ -91,7 +91,7 @@ if ($secret == Configuration::get('BLOCKONOMICS_CALLBACK_SECRET')) {
             }
             
             if (isset($new_order_state)) {
-                foreach($linked_orders as $linked_order) {
+                foreach ($linked_orders as $linked_order) {
                     $linked_order->setCurrentState($new_order_state);
                 }
                 insertTXIDIntoPaymentDetails($o, $order[0]['txid'], $order[0]);

--- a/callback.php
+++ b/callback.php
@@ -78,13 +78,21 @@ if ($secret == Configuration::get('BLOCKONOMICS_CALLBACK_SECRET')) {
             }
             //Update order status
             $o = new Order($order[0]['id_order']);
-
+            $linked_orders = $o->getByReference($o->reference);
+            $new_order_state = NULL;
+            
             if ($status == 2) {
                 if ($order[0]['bits'] > $order[0]['bits_payed']) {
-                    $o->setCurrentState(Configuration::get('PS_OS_ERROR'));
+                    $new_order_state = Configuration::get('PS_OS_ERROR');
                 } else {
                     Context::getContext()->currency = new Currency($o->id_currency);
-                    $o->setCurrentState(Configuration::get('PS_OS_PAYMENT'));
+                    $new_order_state = Configuration::get('PS_OS_PAYMENT');
+                }
+            }
+            
+            if (isset($new_order_state)) {
+                foreach($linked_orders as $linked_order) {
+                    $linked_order->setCurrentState($new_order_state);
                 }
                 insertTXIDIntoPaymentDetails($o, $order[0]['txid'], $order[0]);
             }


### PR DESCRIPTION
Fixes #138 

Using the id_order stored, the order with the same reference number is fetched, and all the underlying orders are then updated for paid status.