### PR TITLE
Fix generate new callback secret

### DIFF
--- a/blockonomics.php
+++ b/blockonomics.php
@@ -763,8 +763,14 @@ class Blockonomics extends PaymentModule
         Configuration::updateValue('BLOCKONOMICS_CALLBACK_SECRET', $secret);
     }
 
+    /*
+     * Ensures module settings apply to all stores
+     * Fixes PS multistore issues by using single
+     * Blockonomics settings for all stores
+     */
     public function setShopContextAll()
     {
+        // Check if the multistore feature is activated
         if (Shop::isFeatureActive()) {
             Shop::setContext(Shop::CONTEXT_ALL);
         }

--- a/blockonomics.php
+++ b/blockonomics.php
@@ -511,7 +511,7 @@ class Blockonomics extends PaymentModule
                 );
             }
         } elseif (Tools::isSubmit('generateNewSecret')) {
-            $this->generatenewCallbackSecret();
+            $this->generateNewCallbackSecret();
         }
         return $output . $this->displayForm();
     }
@@ -697,7 +697,7 @@ class Blockonomics extends PaymentModule
         );
         $callback_secret = Configuration::get('BLOCKONOMICS_CALLBACK_SECRET');
         if (!$callback_secret) {
-            $this->generatenewCallback();
+            $this->generateNewCallbackSecret();
             $callback_secret = Configuration::get('BLOCKONOMICS_CALLBACK_SECRET');
         }
         $helper->fields_value['callbackURL'] = Context::getContext()->shop->getBaseURL(true).

--- a/blockonomics.php
+++ b/blockonomics.php
@@ -157,8 +157,7 @@ class Blockonomics extends PaymentModule
         Configuration::updateValue('BLOCKONOMICS_LOGO_HEIGHT', "0");
 
         //Generate callback secret
-        $secret = md5(uniqid(rand(), true));
-        Configuration::updateValue('BLOCKONOMICS_CALLBACK_SECRET', $secret);
+        $this->generateNewCallbackSecret();
         return true;
     }
 

--- a/blockonomics.php
+++ b/blockonomics.php
@@ -407,7 +407,8 @@ class Blockonomics extends PaymentModule
     {
         $this->setShopContextAll();
         $callback_secret = Configuration::get('BLOCKONOMICS_CALLBACK_SECRET');
-        $api_url = Context::getContext()->shop->getBaseURL(true) . 'modules/' . $this->name;
+        
+        $api_url = Tools::getHttpHost(true).__PS_BASE_URI__ . 'modules/' . $this->name;
         $presta_callback_url = $api_url . '/callback.php?secret=' . $callback_secret;
         $base_url = preg_replace('/https?:\/\//', '', $api_url);
         $available_xpub = '';
@@ -713,7 +714,7 @@ class Blockonomics extends PaymentModule
             $this->generateNewCallbackSecret();
             $callback_secret = Configuration::get('BLOCKONOMICS_CALLBACK_SECRET');
         }
-        $helper->fields_value['callbackURL'] = Context::getContext()->shop->getBaseURL(true).
+        $helper->fields_value['callbackURL'] = Tools::getHttpHost(true).__PS_BASE_URI__.
         'modules/' .
         $this->name .
         '/callback.php?secret=' .

--- a/blockonomics.php
+++ b/blockonomics.php
@@ -41,7 +41,7 @@ class Blockonomics extends PaymentModule
     {
         $this->name = 'blockonomics';
         $this->tab = 'payments_gateways';
-        $this->version = '1.7.94';
+        $this->version = '1.7.95';
         $this->author = 'Blockonomics';
         $this->need_instance = 1;
         $this->bootstrap = true;

--- a/blockonomics.php
+++ b/blockonomics.php
@@ -156,8 +156,14 @@ class Blockonomics extends PaymentModule
         Configuration::updateValue('BLOCKONOMICS_BCH', false);
         Configuration::updateValue('BLOCKONOMICS_LOGO_HEIGHT', "0");
 
-        //Generate callback secret
-        $this->generateNewCallbackSecret();
+        /* Setup each shop secret */
+        $shops = Shop::getShops();
+        foreach ($shops as $shop) {
+            /* Sets up configuration */
+            $secret = md5(uniqid(rand(), true));
+            Configuration::updateValue('BLOCKONOMICS_CALLBACK_SECRET', $secret, false, 0, $shop['id_shop']);
+        }
+
         return true;
     }
 

--- a/blockonomics.php
+++ b/blockonomics.php
@@ -715,6 +715,9 @@ class Blockonomics extends PaymentModule
 
     public function updateSettings()
     {
+        if (Shop::isFeatureActive() && Shop::getContext() == Shop::CONTEXT_GROUP) {
+            return $this->displayError($this->l('Cannot save settings for a shop group. Setup each shop individually'));
+        }
         Configuration::updateValue(
             'BLOCKONOMICS_API_KEY',
             Tools::getValue('BLOCKONOMICS_API_KEY')
@@ -748,6 +751,9 @@ class Blockonomics extends PaymentModule
 
     public function generateNewCallbackSecret()
     {
+        if (Shop::isFeatureActive() && Shop::getContext() == Shop::CONTEXT_GROUP) {
+            return;
+        }
         $secret = md5(uniqid(rand(), true));
         Configuration::updateValue('BLOCKONOMICS_CALLBACK_SECRET', $secret);
     }

--- a/callback.php
+++ b/callback.php
@@ -27,6 +27,7 @@ $value = Tools::getValue('value');
 $status = Tools::getValue('status');
 $addr = Tools::getValue('addr');
 
+// Check if the multistore feature is activated
 if (Shop::isFeatureActive()) {
     Shop::setContext(Shop::CONTEXT_ALL);
 }

--- a/callback.php
+++ b/callback.php
@@ -27,6 +27,9 @@ $value = Tools::getValue('value');
 $status = Tools::getValue('status');
 $addr = Tools::getValue('addr');
 
+if (Shop::isFeatureActive()) {
+    Shop::setContext(Shop::CONTEXT_ALL);
+}
 //Match secret for callback
 if ($secret == Configuration::get('BLOCKONOMICS_CALLBACK_SECRET')) {
      // Update kernel initialization for Prestashop 1.7.6.1

--- a/controllers/front/payment.php
+++ b/controllers/front/payment.php
@@ -149,6 +149,7 @@ class BlockonomicsPaymentModuleFrontController extends ModuleFrontController
             );
 
             $mes = "Adr BTC : " . $address;
+            $blockonomics->installOrder('BLOCKONOMICS_ORDER_STATE_WAIT', 'Awaiting Bitcoin Payment', null);
             $blockonomics->validateOrder(
                 (int) $cart->id,
                 (int) Configuration::get('BLOCKONOMICS_ORDER_STATE_WAIT'),

--- a/controllers/front/payment.php
+++ b/controllers/front/payment.php
@@ -72,6 +72,7 @@ class BlockonomicsPaymentModuleFrontController extends ModuleFrontController
         $cart = $this->context->cart;
         $this->display_column_left = false;
         $blockonomics = $this->module;
+        $blockonomics->setShopContextAll();
         $crypto = $blockonomics->getActiveCurrencies()[Tools::getValue('crypto')];
 
         if (!isset($cart->id) or
@@ -149,7 +150,7 @@ class BlockonomicsPaymentModuleFrontController extends ModuleFrontController
             );
 
             $mes = "Adr BTC : " . $address;
-            $blockonomics->installOrder('BLOCKONOMICS_ORDER_STATE_WAIT', 'Awaiting Bitcoin Payment', null);
+
             $blockonomics->validateOrder(
                 (int) $cart->id,
                 (int) Configuration::get('BLOCKONOMICS_ORDER_STATE_WAIT'),
@@ -314,6 +315,8 @@ class BlockonomicsPaymentModuleFrontController extends ModuleFrontController
     private function getTimeRemaining($order)
     {
         if ($order) {
+            $blockonomics = $this->module;
+            $blockonomics->setShopContextAll();
             $time_remaining = ($order['timestamp'] +
             (Configuration::get('BLOCKONOMICS_TIMEPERIOD') * 60) - time()) / 60;
             if ($time_remaining > 0) {


### PR DESCRIPTION
Fixes for issue #144

Prestashop Multisite is causing this issue due to the incorrect function name. This function is currently separate to generating the secret on module installation, which does not run for each multisite: https://github.com/blockonomics/prestashop-plugin/blob/1.7/blockonomics.php#L160-L161
- The function name has been corrected, which fixes this issue. [d9bb4db](https://github.com/blockonomics/prestashop-plugin/commit/d9bb4db7edff88e698a89caf514997437ace9897)
- The secret generation on module installation has been refactored to use the same function. [4e4f375](https://github.com/blockonomics/prestashop-plugin/commit/4e4f375ac2b244692bc664d3a3457a9adda74ac5)

The order status is also not created for each multisite: https://github.com/blockonomics/prestashop-plugin/blob/1.7/blockonomics.php#L76. This leads to issue on checkout
![Checkout issue](https://user-images.githubusercontent.com/39666372/156182479-580d1861-c798-4829-8c5a-3d883de1ac76.png)
- Ensures the Blockonomics order status is set before order validation [d05c8f1](https://github.com/blockonomics/prestashop-plugin/commit/d05c8f1f948f3572c33da2b77efde1432217fcc3)

The module can be installed for multiple stores at a time as well as individually.
1. Stores use separate Callback URLs
2. Each Store requires module setup (New xpub, set API, Test Setup)
Note: Prestashop uses shop groups to edit module settings for multiple shops at a time. This leads the group to have a secret separate to the individual shop. To prevent this, either editing the settings for a group should be prevented:
```
if (Shop::isFeatureActive() && Shop::getContext() == Shop::CONTEXT_GROUP) {
    return;
}
```
or all the shops should use the same module settings, however we will be required to fully test the impact of this option especially with regards to the callback URL/URLs:
```
if (Shop::isFeatureActive()) {
    Shop::setContext(Shop::CONTEXT_ALL);
}
``` 
