### PR TITLE
Add advanced settings

### DIFF
--- a/blockonomics.php
+++ b/blockonomics.php
@@ -526,16 +526,6 @@ class Blockonomics extends PaymentModule
                     )
                 );
             }
-        } elseif (Tools::isSubmit('updateAdvanceSettings')) {
-            $output = $this->updateAdvanceSettings();
-            if (!$output) {
-                $output = $this->displayConfirmation(
-                    $this->l(
-                        // removing the "click test setup to verify" from message
-                        'Settings Saved'
-                    )
-                );
-            }
         } elseif (Tools::isSubmit('generateNewSecret')) {
             $this->generateNewCallbackSecret();
         }
@@ -572,93 +562,76 @@ class Blockonomics extends PaymentModule
                     'name' => 'callbackURL',
                     'disabled' => 'disabled',
                 ),
+                // Inserting JQuery into HelperForm for advance setting toggle
+                array(
+                  'type' => 'html',
+                  'name' => 'settingToggle',
+                  'class' => 'btn btn-default',
+                  'html_content' => '<script>
+                                        $(document).ready(function() {
+                                          $("#advance-settings-toggle").click(function(){
+                                            $("#advance-settings-1").parent().parent().toggleClass("hide");
+                                            $("#advance-settings-2").parent().parent().toggleClass("hide");
+                                            $("#advance-settings-3").parent().parent().toggleClass("hide");
+                                            if ($("#advance-settings-toggle").text().trim() === "Show Advanced Settings")
+                                            {
+                                                $("#advance-settings-toggle").text("Hide Advanced Settings");
+                                            } else 
+                                            {
+                                                $("#advance-settings-toggle").text("Show Advanced Settings");
+                                            }
+                                          });
+                                        });
+                                      </script>
+                                      <button type="button" id="advance-settings-toggle" class="btn btn-default btn-lg">
+                                        Show Advanced Settings
+                                      </button>',
+              ),                
+              array(
+                  'type' => 'select',
+                  'label' => $this->l('Time Period'),
+                  'name' => 'BLOCKONOMICS_TIMEPERIOD',
+                  'desc' => $this->l('Countdown timer on payment page'),
+                  'required' => false,
+                  'id' => 'advance-settings-1',
+                  'form_group_class' => 'hide',
+                  'options' => array(
+                      'query' => array(
+                          array('key' => '10', 'name' => $this->l('10 minutes')),
+                          array('key' => '15', 'name' => $this->l('15 minutes')),
+                          array('key' => '20', 'name' => $this->l('20 minutes')),
+                          array('key' => '25', 'name' => $this->l('25 minutes')),
+                          array('key' => '30', 'name' => $this->l('30 minutes')),
+                      ),
+                      'id' => 'key',
+                      'name' => 'name',
+                  ),
+              ),
+              array(
+                  'type' => 'text',
+                  'label' => $this->l('Pay by bitcoin icon size'),
+                  'desc' => $this->l(
+                      'Size in pixels.
+                       Set 0 to disable icon'
+                  ),
+                  'name' => 'BLOCKONOMICS_LOGO_HEIGHT',
+                  'required' => false,
+                  'class' => 'fixed-width-xl',
+                  'form_group_class' => 'hide',
+                  'id' => 'advance-settings-2',
+              ),
+              array(
+                  'type' => 'html',
+                  'label' => $this->l('Underpayment Slack %'),
+                  'desc' => $this->l('Allow payments that are off by a small percentage'),
+                  'required' => false,
+                  'form_group_class' => 'hide',
+                  'html_content' => '<input type="number" class="fixed-width-xl" id="advance-settings-3" min=0 max=10 step=0.01 name="BLOCKONOMICS_UNDERPAYMENT_SLACK" value=' . strval($slack_value) . '>',
+              ),
             ),
             'submit' => array(
                 'title' => $this->l('Save'),
                 'name' => 'updateSettings',
-                'class' => 'btn btn-default pull-right',
-            ),
-        );
-        $fields_form[1]['form'] = array(
-            'input' => array(
-                array(
-                    'type' => 'html',
-#                    'title' => $this->l('Show More options'),
-                    'name' => 'testSetup',
-                    'class' => 'btn btn-default',
-                    'html_content' => '
-                            <button onclick="showAdvanced()" type="button" id="show-advance" style="display: none" class="btn btn-default btn-lg"> Hide Advanced Settings &#9650</button>
-                            <button onclick="showAdvanced()" type="button" id="show-basic" style="display:block" class="btn btn-default btn-lg"> Show Advanced Settings &#9660</button>
-                            <script type="text/javascript">
-                            window.onload = function(){
-                                document.getElementById("fieldset_2_2").style.display="none";
-                              };
-
-                            function showAdvanced() {
-                            if (document.getElementById("fieldset_2_2").style.display == "none"){
-                            document.getElementById("fieldset_2_2").style.display = "block";
-                            document.getElementById("show-basic").style.display = "none";
-                            document.getElementById("show-advance").style.display = "block";
-
-                            }
-                            else {
-                            document.getElementById("fieldset_2_2").style.display = "none";
-                            document.getElementById("show-basic").style.display = "block";
-                            document.getElementById("show-advance").style.display = "none";
-                            }
-                            }
-                            </script>
-                            ',
-                ),
-            ),
-        );
-        $fields_form[2]['form'] = array(
-            'legend' => array(
-                'title' => $this->l('More Settings'),
-            ),
-            'input' => array(
-                array(
-                    'type' => 'select',
-                    'label' => $this->l('Time Period'),
-                    'name' => 'BLOCKONOMICS_TIMEPERIOD',
-                    'desc' => $this->l('Countdown timer on payment page'),
-                    'required' => false,
-                    'id' => 'advanced-setting',
-                    'options' => array(
-                        'query' => array(
-                            array('key' => '10', 'name' => $this->l('10 minutes')),
-                            array('key' => '15', 'name' => $this->l('15 minutes')),
-                            array('key' => '20', 'name' => $this->l('20 minutes')),
-                            array('key' => '25', 'name' => $this->l('25 minutes')),
-                            array('key' => '30', 'name' => $this->l('30 minutes')),
-                        ),
-                        'id' => 'key',
-                        'name' => 'name',
-                    ),
-                ),
-                array(
-                    'type' => 'text',
-                    'label' => $this->l('Pay by bitcoin icon size'),
-                    'desc' => $this->l(
-                        'Size in pixels.
-                         Set 0 to disable icon'
-                    ),
-                    'name' => 'BLOCKONOMICS_LOGO_HEIGHT',
-                    'required' => false,
-                    'class' => 'fixed-width-xl',
-                    'id' => 'advanced-setting',
-                ),
-                array(
-                    'type' => 'html',
-                    'label' => $this->l('Underpayment Slack %'),
-                    'desc' => $this->l('Allow payments that are off by a small percentage'),
-                    'required' => false,
-                    'html_content' => '<input type="number" class="fixed-width-xl" id="advanced-setting" min=0 max=10 step=0.01 name="BLOCKONOMICS_UNDERPAYMENT_SLACK" value=' . strval($slack_value) . '>',
-                ),
-            ),
-            'submit' => array(
-                'title' => $this->l('Save'),
-                'name' => 'updateAdvanceSettings',
                 'class' => 'btn btn-default pull-right',
             ),
         );
@@ -668,7 +641,7 @@ class Blockonomics extends PaymentModule
         ' <b>'. $this->l('Get Started for Free'). '</b> ' .
         $this->l('on');
 
-        $fields_form[3]['form'] = array(
+        $fields_form[1]['form'] = array(
             'legend' => array(
                 'title' => $this->l('Currencies')
             ),
@@ -801,6 +774,14 @@ class Blockonomics extends PaymentModule
             Tools::getValue('BLOCKONOMICS_API_KEY')
         );
         Configuration::updateValue(
+            'BLOCKONOMICS_TIMEPERIOD',
+            Tools::getValue('BLOCKONOMICS_TIMEPERIOD')
+        );
+        Configuration::updateValue(
+            'BLOCKONOMICS_UNDERPAYMENT_SLACK',
+            Tools::getValue('BLOCKONOMICS_UNDERPAYMENT_SLACK')
+        );
+        Configuration::updateValue(
             'BLOCKONOMICS_BTC',
             Tools::getValue('BLOCKONOMICS_BTC')
         );
@@ -809,32 +790,18 @@ class Blockonomics extends PaymentModule
             Tools::getValue('BLOCKONOMICS_BCH')
         );
 
-        if (!Configuration::get('BLOCKONOMICS_API_KEY')) {
-            return $this->displayError($this->l('Please specify an API Key'));
-        }
-    }
-
-    public function updateAdvanceSettings()
-    {
-        $this->setShopContextAll();
-        Configuration::updateValue(
-            'BLOCKONOMICS_TIMEPERIOD',
-            Tools::getValue('BLOCKONOMICS_TIMEPERIOD')
-        );
-        Configuration::updateValue(
-            'BLOCKONOMICS_UNDERPAYMENT_SLACK',
-            Tools::getValue('BLOCKONOMICS_UNDERPAYMENT_SLACK')
-        );
-
         $logoHeight = Tools::getValue('BLOCKONOMICS_LOGO_HEIGHT');
         if ($logoHeight) {
             $logoHeight = preg_replace("/[^0-9]/", "", $logoHeight);
         }
-
+    
         Configuration::updateValue(
             'BLOCKONOMICS_LOGO_HEIGHT',
             $logoHeight
         );
+        if (!Configuration::get('BLOCKONOMICS_API_KEY')) {
+            return $this->displayError($this->l('Please specify an API Key'));
+        }
     }
 
     public function generateNewCallbackSecret()

--- a/blockonomics.php
+++ b/blockonomics.php
@@ -569,23 +569,22 @@ class Blockonomics extends PaymentModule
                   'class' => 'btn btn-default',
                   'html_content' => '<script>
                                         $(document).ready(function() {
-                                          $("#advance-settings-toggle").click(function(){
-                                            $("#advance-settings-1").parent().parent().toggleClass("hide");
-                                            $("#advance-settings-2").parent().parent().toggleClass("hide");
-                                            $("#advance-settings-3").parent().parent().toggleClass("hide");
-                                            if ($("#advance-settings-toggle").text().trim() === "Show Advanced Settings")
-                                            {
-                                                $("#advance-settings-toggle").text("Hide Advanced Settings");
-                                            } else 
-                                            {
-                                                $("#advance-settings-toggle").text("Show Advanced Settings");
+                                          $("#advanced_title").click(function(){
+                                            $("#advanced_title_1").parent().parent().toggleClass("hide");
+                                            $("#advanced_title_2").parent().parent().toggleClass("hide");
+                                            $("#advanced_title_3").parent().parent().toggleClass("hide");
+                                            if ($("#advanced_title").text().trim() === "Advanced Settings ▼"){
+                                                $("#advanced_title").text("Advanced Settings ▲");
+                                            } 
+                                            else {
+                                                $("#advanced_title").text("Advanced Settings ▼");
                                             }
                                           });
                                         });
                                       </script>
-                                      <button type="button" id="advance-settings-toggle" class="btn btn-default btn-lg">
-                                        Show Advanced Settings
-                                      </button>',
+                                      <a id="advanced_title" style="cursor: pointer; font-weight: bold">
+                                        Advanced Settings &#9660
+                                      </a>',
               ),                
               array(
                   'type' => 'select',
@@ -593,7 +592,7 @@ class Blockonomics extends PaymentModule
                   'name' => 'BLOCKONOMICS_TIMEPERIOD',
                   'desc' => $this->l('Countdown timer on payment page'),
                   'required' => false,
-                  'id' => 'advance-settings-1',
+                  'id' => 'advanced_title_1',
                   'form_group_class' => 'hide',
                   'options' => array(
                       'query' => array(
@@ -618,7 +617,7 @@ class Blockonomics extends PaymentModule
                   'required' => false,
                   'class' => 'fixed-width-xl',
                   'form_group_class' => 'hide',
-                  'id' => 'advance-settings-2',
+                  'id' => 'advanced_title_2',
               ),
               array(
                   'type' => 'html',
@@ -627,7 +626,7 @@ class Blockonomics extends PaymentModule
                   'desc' => $this->l('Allow payments that are off by a small percentage'),
                   'required' => false,
                   'form_group_class' => 'hide',
-                  'html_content' => '<input type="number" class="fixed-width-xl" id="advance-settings-3" min=0 max=20 step=0.01 name="BLOCKONOMICS_UNDERPAYMENT_SLACK" value=' . strval($slack_value) . '>',
+                  'html_content' => '<input type="number" class="fixed-width-xl" id="advanced_title_3" min=0 max=20 step=0.01 name="BLOCKONOMICS_UNDERPAYMENT_SLACK" value=' . strval($slack_value) . '>',
               ),
             ),
             'submit' => array(

--- a/blockonomics.php
+++ b/blockonomics.php
@@ -627,7 +627,7 @@ class Blockonomics extends PaymentModule
                   'desc' => $this->l('Allow payments that are off by a small percentage'),
                   'required' => false,
                   'form_group_class' => 'hide',
-                  'html_content' => '<input type="number" class="fixed-width-xl" id="advance-settings-3" min=0 max=10 step=0.01 name="BLOCKONOMICS_UNDERPAYMENT_SLACK" value=' . strval($slack_value) . '>',
+                  'html_content' => '<input type="number" class="fixed-width-xl" id="advance-settings-3" min=0 max=20 step=0.01 name="BLOCKONOMICS_UNDERPAYMENT_SLACK" value=' . strval($slack_value) . '>',
               ),
             ),
             'submit' => array(

--- a/blockonomics.php
+++ b/blockonomics.php
@@ -777,16 +777,6 @@ class Blockonomics extends PaymentModule
             'BLOCKONOMICS_TIMEPERIOD',
             Tools::getValue('BLOCKONOMICS_TIMEPERIOD')
         );
-        $underpaymentSlack = Tools::getValue('BLOCKONOMICS_UNDERPAYMENT_SLACK');
-        if (0 <= $underpaymentSlack && $underpaymentSlack <= 20){
-            Configuration::updateValue(
-                'BLOCKONOMICS_UNDERPAYMENT_SLACK',
-                Tools::getValue('BLOCKONOMICS_UNDERPAYMENT_SLACK')
-            );
-        }
-        else {
-            return $this->displayError($this->l('Invalid Underpayment Slack. Enter a value between 0 to 20'));
-        }
         Configuration::updateValue(
             'BLOCKONOMICS_BTC',
             Tools::getValue('BLOCKONOMICS_BTC')
@@ -807,6 +797,17 @@ class Blockonomics extends PaymentModule
         );
         if (!Configuration::get('BLOCKONOMICS_API_KEY')) {
             return $this->displayError($this->l('Please specify an API Key'));
+        }
+        
+        $underpayment_slack = Tools::getValue('BLOCKONOMICS_UNDERPAYMENT_SLACK');        
+        if (0 <= $underpayment_slack && $underpayment_slack <= 20){
+            Configuration::updateValue(
+                'BLOCKONOMICS_UNDERPAYMENT_SLACK',
+                Tools::getValue('BLOCKONOMICS_UNDERPAYMENT_SLACK')
+            );
+        }
+        else {
+            return $this->displayError($this->l('Invalid Underpayment Slack. Enter a value between 0 to 20'));
         }
     }
 

--- a/blockonomics.php
+++ b/blockonomics.php
@@ -586,6 +586,14 @@ class Blockonomics extends PaymentModule
                     'name'     => 'BLOCKONOMICS_LOGO_HEIGHT',
                     'required' => false,
                     'class'    => 'fixed-width-xl'
+                ),
+                array(
+                    'type'     => 'html',
+                    'label'    => $this->l('Underpayment Slack %'),
+                    'desc'     => $this->l('Allow payments that are off by a small percentage'),
+                    'required' => false,
+                    #'class'    => 'fixed-width-xl',
+                    'html_content' => '<input type="number" min=0 max=10 step=0.01 name="BLOCKONOMICS_UNDERPAYMENT_SLACK" value="">'
                 )
             ),
             'submit' => array(

--- a/blockonomics.php
+++ b/blockonomics.php
@@ -158,6 +158,7 @@ class Blockonomics extends PaymentModule
         Configuration::updateValue('BLOCKONOMICS_TIMEPERIOD', 10);
         Configuration::updateValue('BLOCKONOMICS_BTC', true);
         Configuration::updateValue('BLOCKONOMICS_BCH', false);
+        Configuration::updateValue('BLOCKONOMICS_UNDERPAYMENT_SLACK', 0);
         Configuration::updateValue('BLOCKONOMICS_LOGO_HEIGHT', "0");
 
         /* Sets up shop secret */
@@ -180,6 +181,7 @@ class Blockonomics extends PaymentModule
         Configuration::deleteByName('BLOCKONOMICS_CALLBACK_SECRET');
         Configuration::deleteByName('BLOCKONOMICS_TIMEPERIOD');
         Configuration::deleteByName('BLOCKONOMICS_LOGO_HEIGHT');
+        Configuration::deleteByName('BLOCKONOMICS_UNDERPAYMENT_SLACK');
 
         //We should still delete these values since older versions had them
         Configuration::deleteByName('BLOCKONOMICS_BASE_URL');
@@ -531,6 +533,7 @@ class Blockonomics extends PaymentModule
 
     public function displayForm()
     {
+        $slack_value = Configuration::get('BLOCKONOMICS_UNDERPAYMENT_SLACK');
         $fields_form = array();
         // Init Settings Fields form array; a.k.a. Settings section
         $fields_form[0]['form'] = array(
@@ -593,7 +596,7 @@ class Blockonomics extends PaymentModule
                     'desc'     => $this->l('Allow payments that are off by a small percentage'),
                     'required' => false,
                     #'class'    => 'fixed-width-xl',
-                    'html_content' => '<input type="number" min=0 max=10 step=0.01 name="BLOCKONOMICS_UNDERPAYMENT_SLACK" value="">'
+                    'html_content' => '<input type="number" min=0 max=10 step=0.01 name="BLOCKONOMICS_UNDERPAYMENT_SLACK" value='.strval($slack_value).'>'
                 )
             ),
             'submit' => array(
@@ -711,6 +714,9 @@ class Blockonomics extends PaymentModule
         $helper->fields_value['BLOCKONOMICS_BTC'] = Configuration::get(
             'BLOCKONOMICS_BTC'
         );
+        $helper->fields_value['BLOCKONOMICS_UNDERPAYMENT_SLACK'] = Configuration::get(
+            'BLOCKONOMICS_UNDERPAYMENT_SLACK'
+        );
         $helper->fields_value['BLOCKONOMICS_BCH'] = Configuration::get(
             'BLOCKONOMICS_BCH'
         );
@@ -744,6 +750,10 @@ class Blockonomics extends PaymentModule
         Configuration::updateValue(
             'BLOCKONOMICS_BTC',
             Tools::getValue('BLOCKONOMICS_BTC')
+        );
+        Configuration::updateValue(
+            'BLOCKONOMICS_UNDERPAYMENT_SLACK',
+            Tools::getValue('BLOCKONOMICS_UNDERPAYMENT_SLACK')
         );
         Configuration::updateValue(
             'BLOCKONOMICS_BCH',

--- a/blockonomics.php
+++ b/blockonomics.php
@@ -622,6 +622,7 @@ class Blockonomics extends PaymentModule
               ),
               array(
                   'type' => 'html',
+                  'name' => 'BLOCKONOMICS_UNDERPAYMENT_SLACK',
                   'label' => $this->l('Underpayment Slack %'),
                   'desc' => $this->l('Allow payments that are off by a small percentage'),
                   'required' => false,

--- a/blockonomics.php
+++ b/blockonomics.php
@@ -778,10 +778,16 @@ class Blockonomics extends PaymentModule
             'BLOCKONOMICS_TIMEPERIOD',
             Tools::getValue('BLOCKONOMICS_TIMEPERIOD')
         );
-        Configuration::updateValue(
-            'BLOCKONOMICS_UNDERPAYMENT_SLACK',
-            Tools::getValue('BLOCKONOMICS_UNDERPAYMENT_SLACK')
-        );
+        $underpaymentSlack = Tools::getValue('BLOCKONOMICS_UNDERPAYMENT_SLACK');
+        if (0 <= $underpaymentSlack && $underpaymentSlack <= 20){
+            Configuration::updateValue(
+                'BLOCKONOMICS_UNDERPAYMENT_SLACK',
+                Tools::getValue('BLOCKONOMICS_UNDERPAYMENT_SLACK')
+            );
+        }
+        else {
+            return $this->displayError($this->l('Invalid Underpayment Slack. Enter a value between 0 to 20'));
+        }
         Configuration::updateValue(
             'BLOCKONOMICS_BTC',
             Tools::getValue('BLOCKONOMICS_BTC')

--- a/callback.php
+++ b/callback.php
@@ -83,9 +83,11 @@ if ($secret == Configuration::get('BLOCKONOMICS_CALLBACK_SECRET')) {
             $o = new Order($order[0]['id_order']);
             $linked_orders = $o->getByReference($o->reference);
             $new_order_state = null;
+            // Get underpayment slack
+            $underpayment_slack = Configuration::get('BLOCKONOMICS_UNDERPAYMENT_SLACK')/100 * $order[0]['bits'];
             
             if ($status == 2) {
-                if ($order[0]['bits'] > $order[0]['bits_payed']) {
+                if ($order[0]['bits'] - $underpayment_slack > $order[0]['bits_payed']) {
                     $new_order_state = Configuration::get('PS_OS_ERROR');
                 } else {
                     Context::getContext()->currency = new Currency($o->id_currency);


### PR DESCRIPTION
fixes #146 
- Added underpayment slack %
- Created collapsible for Advanced Settings, it includes:
  - Time Period
  - Pay by bitcoin icon size
  - Underpayment Slack %

![advancedSettings](https://user-images.githubusercontent.com/97018228/180220533-d09b6514-9f76-4294-a7b5-81db7b6d5d71.gif )

## Updates:
- Advanced Settings link UI matches more closely to woocommerce
- Validating the underpayment slack in updateSettings
- When an invalid value is entered, error is shown as follows: 
<img width="525" alt="image" src="https://user-images.githubusercontent.com/97018228/180238017-7b104fe0-ef81-4cbb-ab22-52346fc6d3e4.png">
