### PR TITLE
(fix) Prestashop Module Validator Warnings

### DIFF
--- a/license.txt
+++ b/license.txt
@@ -1,5 +1,5 @@
 /**
- * 2011-2016 Blockonomics
+ * 2011-2022 Blockonomics
  *
  * NOTICE OF LICENSE
  *

--- a/translations/cs.php
+++ b/translations/cs.php
@@ -2,52 +2,101 @@
 
 global $_MODULE;
 $_MODULE = array();
-$_MODULE['<{blockonomics}prestashop>blockonomics_2cd248faec609d132624980e19c7ca97'] = 'Bitcoin – Blockonomics';
-$_MODULE['<{blockonomics}prestashop>blockonomics_c0de713a1b5c4354ebbd1e2227ce971b'] = 'Modul pro přijímání bitcoinových plateb';
-$_MODULE['<{blockonomics}prestashop>blockonomics_876f23178c29dc2552c0b48bf23cd9bd'] = 'Určitě chcete provést odinstalaci?';
-$_MODULE['<{blockonomics}prestashop>blockonomics_2f14ecdf24da27a9fb0ded962aa17e8c'] = 'Zadejte prosím klíč API';
-$_MODULE['<{blockonomics}prestashop>blockonomics_575792812af3733426415dc226913037'] = 'Platba bitcoinem';
-$_MODULE['<{blockonomics}prestashop>blockonomics_db84ee92e4da32563f91afe070e37a7e'] = 'Váš server blokuje odchozí volání HTTPS';
-$_MODULE['<{blockonomics}prestashop>blockonomics_71d736bf8acac6f396861493102750d1'] = 'Klíč API je nesprávný';
-$_MODULE['<{blockonomics}prestashop>blockonomics_baa8441e3dbb790354e36e17e77d960a'] = 'Přidejte nový obchod na web blockonomics';
-$_MODULE['<{blockonomics}prestashop>blockonomics_98c2637920a4f98d40f7f6b0fc2fd378'] = 'Další informace naleznete v tomto článku';
-$_MODULE['<{blockonomics}prestashop>blockonomics_c3d515262545a5bde7c683f68afe06f9'] = 'o řešení problémů';
-$_MODULE['<{blockonomics}prestashop>blockonomics_f75cbf4937d2f1f31e6a4c727ebfee7b'] = 'Nastavení je hotové!';
-$_MODULE['<{blockonomics}prestashop>blockonomics_e576911d3083c76abba01c8a03842856'] = 'Po uložení nastavení klikněte na Nastavení testu a ověřte instalaci.';
-$_MODULE['<{blockonomics}prestashop>blockonomics_f4f70727dc34561dfde1a3c529b6205c'] = 'Nastavení';
-$_MODULE['<{blockonomics}prestashop>blockonomics_d876ff8da67c3731ae25d8335a4168b4'] = 'Klíč API';
-$_MODULE['<{blockonomics}prestashop>blockonomics_4090c73f435e12febebe689cdf79031e'] = 'ZPĚTNÉ VOLÁNÍ HTTP URL';
-$_MODULE['<{blockonomics}prestashop>blockonomics_ff64c6d108f9d4760aaf521fbbabbe8f'] = 'Časové období';
-$_MODULE['<{blockonomics}prestashop>blockonomics_1d916369325e045bba284bcbce35ccaf'] = 'Časovač odpočítávání na stránce platby';
-$_MODULE['<{blockonomics}prestashop>blockonomics_70abb32fcb0c9e8194526d1eef15eb05'] = '10 minut';
-$_MODULE['<{blockonomics}prestashop>blockonomics_2a7bb67d9681d8b5c8241cd49c734772'] = '15 minut';
-$_MODULE['<{blockonomics}prestashop>blockonomics_f31f3ebbdee89a50923676a58da95904'] = '20 minut';
-$_MODULE['<{blockonomics}prestashop>blockonomics_92f08914683ec10736d27ad9a15fa624'] = '25 minut';
-$_MODULE['<{blockonomics}prestashop>blockonomics_0d714869027c4e08ea9b2943d9bd704e'] = '30 minut';
-$_MODULE['<{blockonomics}prestashop>blockonomics_c9cc8cce247e49bae79f15173ce97354'] = 'Uložit';
-$_MODULE['<{blockonomics}prestashop>blockonomics_a17379a9752f2e6eef6c319c771f5f44'] = 'Chcete-li provést konfiguraci, klikněte ';
-$_MODULE['<{blockonomics}prestashop>blockonomics_64f676ae6e961fa1e596eeeeef5c7df9'] = 'na možnost Začít zdarma';
-$_MODULE['<{blockonomics}prestashop>blockonomics_ed2b5c0139cec8ad2873829dc1117d50'] = 'na';
-$_MODULE['<{blockonomics}prestashop>blockonomics_dfcfc43722eef1eab1e4a12e50a068b1'] = 'Měny';
-$_MODULE['<{blockonomics}prestashop>blockonomics_bfacb577033fa77ff21438e5ff80ca3b'] = 'Bitcoin (BTC)';
-$_MODULE['<{blockonomics}prestashop>blockonomics_9cb7ca5565d6c28ff385f66a173c86a7'] = 'Bitcoin Cash (BCH)';
-$_MODULE['<{blockonomics}prestashop>blockonomics_b279be2ec798cea1e5019824662e53e9'] = 'Nastavení testu';
-$_MODULE['<{blockonomics}prestashop>payment_d1228f5476d15142b1358ae4b5fa2454'] = 'Č. objednávky';
-$_MODULE['<{blockonomics}prestashop>payment_8fd2d4cb88dd67be9d343d3398ca763d'] = 'Platba vypršela';
-$_MODULE['<{blockonomics}prestashop>payment_79d7ff78f59371847aa73f232be2d196'] = 'Klikněte sem a zkuste to znovu';
-$_MODULE['<{blockonomics}prestashop>payment_9e553ea6221b688a01e329cf76dde4bf'] = 'Uhrazená částka objednávky v BTC je nižší než očekávaná. Kontakt na obchodníka';
-$_MODULE['<{blockonomics}prestashop>payment_a217a4286be5ab0bd03a98d33a78c420'] = 'K úhradě zašlete přesně tuto částku';
-$_MODULE['<{blockonomics}prestashop>payment_4972448661ca72aa783da607f9b3ecc7'] = 'K úhradě zašlete přesně';
-$_MODULE['<{blockonomics}prestashop>payment_efc1a46f7b47e4d3cf60f13b6c89069b'] = 'Zkopírováno do schránky';
-$_MODULE['<{blockonomics}prestashop>payment_b187de06406775bc913d0c12c6a5dbe6'] = 'Na tuto';
-$_MODULE['<{blockonomics}prestashop>payment_ea08ae01e95bb85ba4d51f7fa224a956'] = 'adresu';
-$_MODULE['<{blockonomics}prestashop>payment_df9e1aa4940f7a34263d65ef41b87cf1'] = 'min';
-$_MODULE['<{blockonomics}prestashop>payment_7f0801830c4f3ed63e81fc0053177394'] = 'Jak zaplatím? | Podívejte se na recenze tohoto obchodu';
-$_MODULE['<{blockonomics}prestashop>payment_69616e342259a7da05c26802caf4f0ea'] = 'Používá technologii Blockonomics';
-$_MODULE['<{blockonomics}prestashop>no_crypto_7a686f1321744105bd4183854107d431'] = 'Na pokladně nejsou umožněny žádné kryptoměny';
-$_MODULE['<{blockonomics}prestashop>no_crypto_6387ce01d8a5c7eff4bfc2e74afc1767'] = 'Poznámka pro webmastera: Lze je aktivovat prostřednictvím PrestaShop Admin > Moduly > Správce modulů > Bitcoin – Blockonomics > Měny ';
-$_MODULE['<{blockonomics}prestashop>select_03a7faed722f23ed1f61d3a49425200b'] = 'Platit pomocí';
-$_MODULE['<{blockonomics}prestashop>validation_02cb6e7914265feb537fe7078c7a5649'] = 'Chybějící rozšíření PHP.';
-$_MODULE['<{blockonomics}prestashop>validation_5dbacc8b4262eb20aa2ec42ab2a1ac0b'] = 'Nainstalujte prosím chybějící rozšíření php-intl';
-$_MODULE['<{blockonomics}prestashop>payment_eb60ab14749e5732652e66fbaf2bd75e'] = 'Nelze vygenerovat bitcoinovou adresu.';
-$_MODULE['<{blockonomics}prestashop>payment_b5511b23e304849b337641e03b9223de'] = 'Pro diagnostiku chyby použijte tlačítko Nastavení testu v konfiguraci';
+$_MODULE['<{blockonomics}prestashop>blockonomics_2cd248faec609d132624980e19c7ca97']
+    = 'Bitcoin – Blockonomics';
+$_MODULE['<{blockonomics}prestashop>blockonomics_c0de713a1b5c4354ebbd1e2227ce971b']
+    = 'Modul pro přijímání bitcoinových plateb';
+$_MODULE['<{blockonomics}prestashop>blockonomics_876f23178c29dc2552c0b48bf23cd9bd']
+    = 'Určitě chcete provést odinstalaci?';
+$_MODULE['<{blockonomics}prestashop>blockonomics_2f14ecdf24da27a9fb0ded962aa17e8c']
+    = 'Zadejte prosím klíč API';
+$_MODULE['<{blockonomics}prestashop>blockonomics_575792812af3733426415dc226913037']
+    = 'Platba bitcoinem';
+$_MODULE['<{blockonomics}prestashop>blockonomics_db84ee92e4da32563f91afe070e37a7e']
+    = 'Váš server blokuje odchozí volání HTTPS';
+$_MODULE['<{blockonomics}prestashop>blockonomics_71d736bf8acac6f396861493102750d1']
+    = 'Klíč API je nesprávný';
+$_MODULE['<{blockonomics}prestashop>blockonomics_baa8441e3dbb790354e36e17e77d960a']
+    = 'Přidejte nový obchod na web blockonomics';
+$_MODULE['<{blockonomics}prestashop>blockonomics_98c2637920a4f98d40f7f6b0fc2fd378']
+    = 'Další informace naleznete v tomto článku';
+$_MODULE['<{blockonomics}prestashop>blockonomics_c3d515262545a5bde7c683f68afe06f9']
+    = 'o řešení problémů';
+$_MODULE['<{blockonomics}prestashop>blockonomics_f75cbf4937d2f1f31e6a4c727ebfee7b']
+    = 'Nastavení je hotové!';
+$_MODULE['<{blockonomics}prestashop>blockonomics_e576911d3083c76abba01c8a03842856']
+    = 'Po uložení nastavení klikněte na Nastavení testu a ověřte instalaci.';
+$_MODULE['<{blockonomics}prestashop>blockonomics_f4f70727dc34561dfde1a3c529b6205c']
+    = 'Nastavení';
+$_MODULE['<{blockonomics}prestashop>blockonomics_d876ff8da67c3731ae25d8335a4168b4']
+    = 'Klíč API';
+$_MODULE['<{blockonomics}prestashop>blockonomics_4090c73f435e12febebe689cdf79031e']
+    = 'ZPĚTNÉ VOLÁNÍ HTTP URL';
+$_MODULE['<{blockonomics}prestashop>blockonomics_ff64c6d108f9d4760aaf521fbbabbe8f']
+    = 'Časové období';
+$_MODULE['<{blockonomics}prestashop>blockonomics_1d916369325e045bba284bcbce35ccaf']
+    = 'Časovač odpočítávání na stránce platby';
+$_MODULE['<{blockonomics}prestashop>blockonomics_70abb32fcb0c9e8194526d1eef15eb05']
+    = '10 minut';
+$_MODULE['<{blockonomics}prestashop>blockonomics_2a7bb67d9681d8b5c8241cd49c734772']
+    = '15 minut';
+$_MODULE['<{blockonomics}prestashop>blockonomics_f31f3ebbdee89a50923676a58da95904']
+    = '20 minut';
+$_MODULE['<{blockonomics}prestashop>blockonomics_92f08914683ec10736d27ad9a15fa624']
+    = '25 minut';
+$_MODULE['<{blockonomics}prestashop>blockonomics_0d714869027c4e08ea9b2943d9bd704e']
+    = '30 minut';
+$_MODULE['<{blockonomics}prestashop>blockonomics_c9cc8cce247e49bae79f15173ce97354']
+    = 'Uložit';
+$_MODULE['<{blockonomics}prestashop>blockonomics_a17379a9752f2e6eef6c319c771f5f44']
+    = 'Chcete-li provést konfiguraci, klikněte ';
+$_MODULE['<{blockonomics}prestashop>blockonomics_64f676ae6e961fa1e596eeeeef5c7df9']
+    = 'na možnost Začít zdarma';
+$_MODULE['<{blockonomics}prestashop>blockonomics_ed2b5c0139cec8ad2873829dc1117d50']
+    = 'na';
+$_MODULE['<{blockonomics}prestashop>blockonomics_dfcfc43722eef1eab1e4a12e50a068b1']
+    = 'Měny';
+$_MODULE['<{blockonomics}prestashop>blockonomics_bfacb577033fa77ff21438e5ff80ca3b']
+    = 'Bitcoin (BTC)';
+$_MODULE['<{blockonomics}prestashop>blockonomics_9cb7ca5565d6c28ff385f66a173c86a7']
+    = 'Bitcoin Cash (BCH)';
+$_MODULE['<{blockonomics}prestashop>blockonomics_b279be2ec798cea1e5019824662e53e9']
+    = 'Nastavení testu';
+$_MODULE['<{blockonomics}prestashop>payment_d1228f5476d15142b1358ae4b5fa2454']
+    = 'Č. objednávky';
+$_MODULE['<{blockonomics}prestashop>payment_8fd2d4cb88dd67be9d343d3398ca763d']
+    = 'Platba vypršela';
+$_MODULE['<{blockonomics}prestashop>payment_79d7ff78f59371847aa73f232be2d196']
+    = 'Klikněte sem a zkuste to znovu';
+$_MODULE['<{blockonomics}prestashop>payment_9e553ea6221b688a01e329cf76dde4bf']
+    = 'Uhrazená částka objednávky v BTC je nižší než očekávaná. Kontakt na obchodníka';
+$_MODULE['<{blockonomics}prestashop>payment_a217a4286be5ab0bd03a98d33a78c420']
+    = 'K úhradě zašlete přesně tuto částku';
+$_MODULE['<{blockonomics}prestashop>payment_4972448661ca72aa783da607f9b3ecc7']
+    = 'K úhradě zašlete přesně';
+$_MODULE['<{blockonomics}prestashop>payment_efc1a46f7b47e4d3cf60f13b6c89069b']
+    = 'Zkopírováno do schránky';
+$_MODULE['<{blockonomics}prestashop>payment_b187de06406775bc913d0c12c6a5dbe6']
+    = 'Na tuto';
+$_MODULE['<{blockonomics}prestashop>payment_ea08ae01e95bb85ba4d51f7fa224a956']
+    = 'adresu';
+$_MODULE['<{blockonomics}prestashop>payment_df9e1aa4940f7a34263d65ef41b87cf1']
+    = 'min';
+$_MODULE['<{blockonomics}prestashop>payment_7f0801830c4f3ed63e81fc0053177394']
+    = 'Jak zaplatím? | Podívejte se na recenze tohoto obchodu';
+$_MODULE['<{blockonomics}prestashop>payment_69616e342259a7da05c26802caf4f0ea']
+    = 'Používá technologii Blockonomics';
+$_MODULE['<{blockonomics}prestashop>no_crypto_7a686f1321744105bd4183854107d431']
+    = 'Na pokladně nejsou umožněny žádné kryptoměny';
+$_MODULE['<{blockonomics}prestashop>no_crypto_6387ce01d8a5c7eff4bfc2e74afc1767']
+    = 'Poznámka pro webmastera: Lze je aktivovat prostřednictvím PrestaShop Admin > Moduly > Správce modulů > Bitcoin – Blockonomics > Měny ';
+$_MODULE['<{blockonomics}prestashop>select_03a7faed722f23ed1f61d3a49425200b']
+    = 'Platit pomocí';
+$_MODULE['<{blockonomics}prestashop>validation_02cb6e7914265feb537fe7078c7a5649']
+    = 'Chybějící rozšíření PHP.';
+$_MODULE['<{blockonomics}prestashop>validation_5dbacc8b4262eb20aa2ec42ab2a1ac0b']
+    = 'Nainstalujte prosím chybějící rozšíření php-intl';
+$_MODULE['<{blockonomics}prestashop>payment_eb60ab14749e5732652e66fbaf2bd75e']
+    = 'Nelze vygenerovat bitcoinovou adresu.';
+$_MODULE['<{blockonomics}prestashop>payment_b5511b23e304849b337641e03b9223de']
+    = 'Pro diagnostiku chyby použijte tlačítko Nastavení testu v konfiguraci';

--- a/translations/cs.php
+++ b/translations/cs.php
@@ -89,7 +89,8 @@ $_MODULE['<{blockonomics}prestashop>payment_69616e342259a7da05c26802caf4f0ea']
 $_MODULE['<{blockonomics}prestashop>no_crypto_7a686f1321744105bd4183854107d431']
     = 'Na pokladně nejsou umožněny žádné kryptoměny';
 $_MODULE['<{blockonomics}prestashop>no_crypto_6387ce01d8a5c7eff4bfc2e74afc1767']
-    = 'Poznámka pro webmastera: Lze je aktivovat prostřednictvím PrestaShop Admin > Moduly > Správce modulů > Bitcoin – Blockonomics > Měny ';
+    = 'Poznámka pro webmastera: Lze je aktivovat prostřednictvím '.
+        'PrestaShop Admin > Moduly > Správce modulů > Bitcoin – Blockonomics > Měny ';
 $_MODULE['<{blockonomics}prestashop>select_03a7faed722f23ed1f61d3a49425200b']
     = 'Platit pomocí';
 $_MODULE['<{blockonomics}prestashop>validation_02cb6e7914265feb537fe7078c7a5649']

--- a/translations/de.php
+++ b/translations/de.php
@@ -2,52 +2,101 @@
 
 global $_MODULE;
 $_MODULE = array();
-$_MODULE['<{blockonomics}prestashop>blockonomics_2cd248faec609d132624980e19c7ca97'] = 'Bitcoin - Blockonomics';
-$_MODULE['<{blockonomics}prestashop>blockonomics_c0de713a1b5c4354ebbd1e2227ce971b'] = 'Modul zur Annahmen Bitcoin-Zahlungen';
-$_MODULE['<{blockonomics}prestashop>blockonomics_876f23178c29dc2552c0b48bf23cd9bd'] = 'Modul wirklich deinstallieren?';
-$_MODULE['<{blockonomics}prestashop>blockonomics_2f14ecdf24da27a9fb0ded962aa17e8c'] = 'Bitte spezifizieren Sie einen API-Schlüssel';
-$_MODULE['<{blockonomics}prestashop>blockonomics_575792812af3733426415dc226913037'] = 'Mit Bitcoin bezahlen';
-$_MODULE['<{blockonomics}prestashop>blockonomics_db84ee92e4da32563f91afe070e37a7e'] = 'Ihr Server blockiert ausgehende HTTPS-Calls';
-$_MODULE['<{blockonomics}prestashop>blockonomics_71d736bf8acac6f396861493102750d1'] = 'API-Schlüssel ist nicht korrekt';
-$_MODULE['<{blockonomics}prestashop>blockonomics_baa8441e3dbb790354e36e17e77d960a'] = 'Bitte fügen Sie einen neuen Shop auf der blockonomics-website hinzu';
-$_MODULE['<{blockonomics}prestashop>blockonomics_98c2637920a4f98d40f7f6b0fc2fd378'] = 'Ausführlichere Information finden Sie in diesen';
-$_MODULE['<{blockonomics}prestashop>blockonomics_c3d515262545a5bde7c683f68afe06f9'] = 'Artikel zur Fehlerbehebung';
-$_MODULE['<{blockonomics}prestashop>blockonomics_f75cbf4937d2f1f31e6a4c727ebfee7b'] = 'Setup wurde abgeschlossen!';
-$_MODULE['<{blockonomics}prestashop>blockonomics_e576911d3083c76abba01c8a03842856'] = 'Die Einstellungen wurden gespeichert, klicken Sie auf TestSetup, um die Installation zu überprüfen';
-$_MODULE['<{blockonomics}prestashop>blockonomics_f4f70727dc34561dfde1a3c529b6205c'] = 'Einstellungen';
-$_MODULE['<{blockonomics}prestashop>blockonomics_d876ff8da67c3731ae25d8335a4168b4'] = 'API-Schlüssel';
-$_MODULE['<{blockonomics}prestashop>blockonomics_4090c73f435e12febebe689cdf79031e'] = 'URL HTTP-CALLBACK ';
-$_MODULE['<{blockonomics}prestashop>blockonomics_ff64c6d108f9d4760aaf521fbbabbe8f'] = 'Dauer';
-$_MODULE['<{blockonomics}prestashop>blockonomics_1d916369325e045bba284bcbce35ccaf'] = 'Countdown-Timer auf Bezahlseite';
-$_MODULE['<{blockonomics}prestashop>blockonomics_70abb32fcb0c9e8194526d1eef15eb05'] = '10 Minuten';
-$_MODULE['<{blockonomics}prestashop>blockonomics_2a7bb67d9681d8b5c8241cd49c734772'] = '15 Minuten';
-$_MODULE['<{blockonomics}prestashop>blockonomics_f31f3ebbdee89a50923676a58da95904'] = '20 Minuten';
-$_MODULE['<{blockonomics}prestashop>blockonomics_92f08914683ec10736d27ad9a15fa624'] = '25 Minuten';
-$_MODULE['<{blockonomics}prestashop>blockonomics_0d714869027c4e08ea9b2943d9bd704e'] = '30 Minuten';
-$_MODULE['<{blockonomics}prestashop>blockonomics_c9cc8cce247e49bae79f15173ce97354'] = 'Speichern';
-$_MODULE['<{blockonomics}prestashop>blockonomics_a17379a9752f2e6eef6c319c771f5f44'] = 'Zum Konfigurieren die Schaltfläche, anklicken';
-$_MODULE['<{blockonomics}prestashop>blockonomics_64f676ae6e961fa1e596eeeeef5c7df9'] = 'Get Started for Free';
-$_MODULE['<{blockonomics}prestashop>blockonomics_ed2b5c0139cec8ad2873829dc1117d50'] = 'auf';
-$_MODULE['<{blockonomics}prestashop>blockonomics_dfcfc43722eef1eab1e4a12e50a068b1'] = 'Währungen';
-$_MODULE['<{blockonomics}prestashop>blockonomics_bfacb577033fa77ff21438e5ff80ca3b'] = 'Bitcoin (BTC)';
-$_MODULE['<{blockonomics}prestashop>blockonomics_9cb7ca5565d6c28ff385f66a173c86a7'] = 'Bitcoin Cash (BCH)';
-$_MODULE['<{blockonomics}prestashop>blockonomics_b279be2ec798cea1e5019824662e53e9'] = 'Test Setup';
-$_MODULE['<{blockonomics}prestashop>payment_d1228f5476d15142b1358ae4b5fa2454'] = 'Bestell-Nr';
-$_MODULE['<{blockonomics}prestashop>payment_8fd2d4cb88dd67be9d343d3398ca763d'] = 'Zahlung abgelaufen';
-$_MODULE['<{blockonomics}prestashop>payment_79d7ff78f59371847aa73f232be2d196'] = 'Hier klicken, um es erneut zu versuchen';
-$_MODULE['<{blockonomics}prestashop>payment_9e553ea6221b688a01e329cf76dde4bf'] = 'Der bezahlte BTC-Betrag der Bestellung ist niedriger als erwartet. Händler kontaktieren';
-$_MODULE['<{blockonomics}prestashop>payment_a217a4286be5ab0bd03a98d33a78c420'] = 'In Wallet öffnen';
-$_MODULE['<{blockonomics}prestashop>payment_4972448661ca72aa783da607f9b3ecc7'] = 'Zum Bezahlen genau diesen Betrag senden';
-$_MODULE['<{blockonomics}prestashop>payment_efc1a46f7b47e4d3cf60f13b6c89069b'] = 'In Zwischenablage kopiert';
-$_MODULE['<{blockonomics}prestashop>payment_b187de06406775bc913d0c12c6a5dbe6'] = 'An diese';
-$_MODULE['<{blockonomics}prestashop>payment_ea08ae01e95bb85ba4d51f7fa224a956'] = ' Adresse';
-$_MODULE['<{blockonomics}prestashop>payment_df9e1aa4940f7a34263d65ef41b87cf1'] = 'min';
-$_MODULE['<{blockonomics}prestashop>payment_7f0801830c4f3ed63e81fc0053177394'] = 'Wie kann ich bezahlen? | Bewertungen zu diesem Shop anzeigen';
-$_MODULE['<{blockonomics}prestashop>payment_69616e342259a7da05c26802caf4f0ea'] = 'Bereitgestellt von Blockonomics';
-$_MODULE['<{blockonomics}prestashop>no_crypto_7a686f1321744105bd4183854107d431'] = 'Für den Zahlvorgang sind keine Kryptowährungen aktiviert';
-$_MODULE['<{blockonomics}prestashop>no_crypto_6387ce01d8a5c7eff4bfc2e74afc1767'] = 'Hinweis an den Webmaster: Aktivierung über PrestaShop Admin > Module > Modul-Manager > Bitcoin - Blockonomics > Währungen';
-$_MODULE['<{blockonomics}prestashop>select_03a7faed722f23ed1f61d3a49425200b'] = 'Bezahlen mit';
-$_MODULE['<{blockonomics}prestashop>validation_02cb6e7914265feb537fe7078c7a5649'] = 'PHP-Erweiterung fehlt.';
-$_MODULE['<{blockonomics}prestashop>validation_5dbacc8b4262eb20aa2ec42ab2a1ac0b'] = 'Bitte die fehlende php-intl-Erweiterung installieren';
-$_MODULE['<{blockonomics}prestashop>payment_eb60ab14749e5732652e66fbaf2bd75e'] = 'Bitcoin-Adresse kann nicht generiert werden.';
-$_MODULE['<{blockonomics}prestashop>payment_b5511b23e304849b337641e03b9223de'] = 'Bitte verwenden Sie die TestSetup-Schaltfläche in der Konfiguration, um den Fehler zu diagnostizieren';
+$_MODULE['<{blockonomics}prestashop>blockonomics_2cd248faec609d132624980e19c7ca97']
+    = 'Bitcoin - Blockonomics';
+$_MODULE['<{blockonomics}prestashop>blockonomics_c0de713a1b5c4354ebbd1e2227ce971b']
+    = 'Modul zur Annahmen Bitcoin-Zahlungen';
+$_MODULE['<{blockonomics}prestashop>blockonomics_876f23178c29dc2552c0b48bf23cd9bd']
+    = 'Modul wirklich deinstallieren?';
+$_MODULE['<{blockonomics}prestashop>blockonomics_2f14ecdf24da27a9fb0ded962aa17e8c']
+    = 'Bitte spezifizieren Sie einen API-Schlüssel';
+$_MODULE['<{blockonomics}prestashop>blockonomics_575792812af3733426415dc226913037']
+    = 'Mit Bitcoin bezahlen';
+$_MODULE['<{blockonomics}prestashop>blockonomics_db84ee92e4da32563f91afe070e37a7e']
+    = 'Ihr Server blockiert ausgehende HTTPS-Calls';
+$_MODULE['<{blockonomics}prestashop>blockonomics_71d736bf8acac6f396861493102750d1']
+    = 'API-Schlüssel ist nicht korrekt';
+$_MODULE['<{blockonomics}prestashop>blockonomics_baa8441e3dbb790354e36e17e77d960a']
+    = 'Bitte fügen Sie einen neuen Shop auf der blockonomics-website hinzu';
+$_MODULE['<{blockonomics}prestashop>blockonomics_98c2637920a4f98d40f7f6b0fc2fd378']
+    = 'Ausführlichere Information finden Sie in diesen';
+$_MODULE['<{blockonomics}prestashop>blockonomics_c3d515262545a5bde7c683f68afe06f9']
+    = 'Artikel zur Fehlerbehebung';
+$_MODULE['<{blockonomics}prestashop>blockonomics_f75cbf4937d2f1f31e6a4c727ebfee7b']
+    = 'Setup wurde abgeschlossen!';
+$_MODULE['<{blockonomics}prestashop>blockonomics_e576911d3083c76abba01c8a03842856']
+    = 'Die Einstellungen wurden gespeichert, klicken Sie auf TestSetup, um die Installation zu überprüfen';
+$_MODULE['<{blockonomics}prestashop>blockonomics_f4f70727dc34561dfde1a3c529b6205c']
+    = 'Einstellungen';
+$_MODULE['<{blockonomics}prestashop>blockonomics_d876ff8da67c3731ae25d8335a4168b4']
+    = 'API-Schlüssel';
+$_MODULE['<{blockonomics}prestashop>blockonomics_4090c73f435e12febebe689cdf79031e']
+    = 'URL HTTP-CALLBACK ';
+$_MODULE['<{blockonomics}prestashop>blockonomics_ff64c6d108f9d4760aaf521fbbabbe8f']
+    = 'Dauer';
+$_MODULE['<{blockonomics}prestashop>blockonomics_1d916369325e045bba284bcbce35ccaf']
+    = 'Countdown-Timer auf Bezahlseite';
+$_MODULE['<{blockonomics}prestashop>blockonomics_70abb32fcb0c9e8194526d1eef15eb05']
+    = '10 Minuten';
+$_MODULE['<{blockonomics}prestashop>blockonomics_2a7bb67d9681d8b5c8241cd49c734772']
+    = '15 Minuten';
+$_MODULE['<{blockonomics}prestashop>blockonomics_f31f3ebbdee89a50923676a58da95904']
+    = '20 Minuten';
+$_MODULE['<{blockonomics}prestashop>blockonomics_92f08914683ec10736d27ad9a15fa624']
+    = '25 Minuten';
+$_MODULE['<{blockonomics}prestashop>blockonomics_0d714869027c4e08ea9b2943d9bd704e']
+    = '30 Minuten';
+$_MODULE['<{blockonomics}prestashop>blockonomics_c9cc8cce247e49bae79f15173ce97354']
+    = 'Speichern';
+$_MODULE['<{blockonomics}prestashop>blockonomics_a17379a9752f2e6eef6c319c771f5f44']
+    = 'Zum Konfigurieren die Schaltfläche, anklicken';
+$_MODULE['<{blockonomics}prestashop>blockonomics_64f676ae6e961fa1e596eeeeef5c7df9']
+    = 'Get Started for Free';
+$_MODULE['<{blockonomics}prestashop>blockonomics_ed2b5c0139cec8ad2873829dc1117d50']
+    = 'auf';
+$_MODULE['<{blockonomics}prestashop>blockonomics_dfcfc43722eef1eab1e4a12e50a068b1']
+    = 'Währungen';
+$_MODULE['<{blockonomics}prestashop>blockonomics_bfacb577033fa77ff21438e5ff80ca3b']
+    = 'Bitcoin (BTC)';
+$_MODULE['<{blockonomics}prestashop>blockonomics_9cb7ca5565d6c28ff385f66a173c86a7']
+    = 'Bitcoin Cash (BCH)';
+$_MODULE['<{blockonomics}prestashop>blockonomics_b279be2ec798cea1e5019824662e53e9']
+    = 'Test Setup';
+$_MODULE['<{blockonomics}prestashop>payment_d1228f5476d15142b1358ae4b5fa2454']
+    = 'Bestell-Nr';
+$_MODULE['<{blockonomics}prestashop>payment_8fd2d4cb88dd67be9d343d3398ca763d']
+    = 'Zahlung abgelaufen';
+$_MODULE['<{blockonomics}prestashop>payment_79d7ff78f59371847aa73f232be2d196']
+    = 'Hier klicken, um es erneut zu versuchen';
+$_MODULE['<{blockonomics}prestashop>payment_9e553ea6221b688a01e329cf76dde4bf']
+    = 'Der bezahlte BTC-Betrag der Bestellung ist niedriger als erwartet. Händler kontaktieren';
+$_MODULE['<{blockonomics}prestashop>payment_a217a4286be5ab0bd03a98d33a78c420']
+    = 'In Wallet öffnen';
+$_MODULE['<{blockonomics}prestashop>payment_4972448661ca72aa783da607f9b3ecc7']
+    = 'Zum Bezahlen genau diesen Betrag senden';
+$_MODULE['<{blockonomics}prestashop>payment_efc1a46f7b47e4d3cf60f13b6c89069b']
+    = 'In Zwischenablage kopiert';
+$_MODULE['<{blockonomics}prestashop>payment_b187de06406775bc913d0c12c6a5dbe6']
+    = 'An diese';
+$_MODULE['<{blockonomics}prestashop>payment_ea08ae01e95bb85ba4d51f7fa224a956']
+    = ' Adresse';
+$_MODULE['<{blockonomics}prestashop>payment_df9e1aa4940f7a34263d65ef41b87cf1']
+    = 'min';
+$_MODULE['<{blockonomics}prestashop>payment_7f0801830c4f3ed63e81fc0053177394']
+    = 'Wie kann ich bezahlen? | Bewertungen zu diesem Shop anzeigen';
+$_MODULE['<{blockonomics}prestashop>payment_69616e342259a7da05c26802caf4f0ea']
+    = 'Bereitgestellt von Blockonomics';
+$_MODULE['<{blockonomics}prestashop>no_crypto_7a686f1321744105bd4183854107d431']
+    = 'Für den Zahlvorgang sind keine Kryptowährungen aktiviert';
+$_MODULE['<{blockonomics}prestashop>no_crypto_6387ce01d8a5c7eff4bfc2e74afc1767']
+    = 'Hinweis an den Webmaster: Aktivierung über PrestaShop Admin > Module > Modul-Manager > Bitcoin - Blockonomics > Währungen';
+$_MODULE['<{blockonomics}prestashop>select_03a7faed722f23ed1f61d3a49425200b']
+    = 'Bezahlen mit';
+$_MODULE['<{blockonomics}prestashop>validation_02cb6e7914265feb537fe7078c7a5649']
+    = 'PHP-Erweiterung fehlt.';
+$_MODULE['<{blockonomics}prestashop>validation_5dbacc8b4262eb20aa2ec42ab2a1ac0b']
+    = 'Bitte die fehlende php-intl-Erweiterung installieren';
+$_MODULE['<{blockonomics}prestashop>payment_eb60ab14749e5732652e66fbaf2bd75e']
+    = 'Bitcoin-Adresse kann nicht generiert werden.';
+$_MODULE['<{blockonomics}prestashop>payment_b5511b23e304849b337641e03b9223de']
+    = 'Bitte verwenden Sie die TestSetup-Schaltfläche in der Konfiguration, um den Fehler zu diagnostizieren';

--- a/translations/de.php
+++ b/translations/de.php
@@ -89,7 +89,8 @@ $_MODULE['<{blockonomics}prestashop>payment_69616e342259a7da05c26802caf4f0ea']
 $_MODULE['<{blockonomics}prestashop>no_crypto_7a686f1321744105bd4183854107d431']
     = 'Für den Zahlvorgang sind keine Kryptowährungen aktiviert';
 $_MODULE['<{blockonomics}prestashop>no_crypto_6387ce01d8a5c7eff4bfc2e74afc1767']
-    = 'Hinweis an den Webmaster: Aktivierung über PrestaShop Admin > Module > Modul-Manager > Bitcoin - Blockonomics > Währungen';
+    = 'Hinweis an den Webmaster: Aktivierung über '.
+        'PrestaShop Admin > Module > Modul-Manager > Bitcoin - Blockonomics > Währungen';
 $_MODULE['<{blockonomics}prestashop>select_03a7faed722f23ed1f61d3a49425200b']
     = 'Bezahlen mit';
 $_MODULE['<{blockonomics}prestashop>validation_02cb6e7914265feb537fe7078c7a5649']

--- a/translations/es.php
+++ b/translations/es.php
@@ -89,7 +89,8 @@ $_MODULE['<{blockonomics}prestashop>payment_69616e342259a7da05c26802caf4f0ea']
 $_MODULE['<{blockonomics}prestashop>no_crypto_7a686f1321744105bd4183854107d431']
     = 'Ninguna criptomoneda está habilitada para el pago';
 $_MODULE['<{blockonomics}prestashop>no_crypto_6387ce01d8a5c7eff4bfc2e74afc1767']
-    = 'Nota para el webmaster: se puede habilitar a través de PrestaShop Admin > Módulos > Administrador de módulos > Bitcoin - Blockonomics > Monedas ';
+    =  'Nota para el webmaster: se puede habilitar a través de '.
+        'PrestaShop Admin > Módulos > Administrador de módulos > Bitcoin - Blockonomics > Monedas ';
 $_MODULE['<{blockonomics}prestashop>select_03a7faed722f23ed1f61d3a49425200b']
     = 'Pagar con';
 $_MODULE['<{blockonomics}prestashop>validation_02cb6e7914265feb537fe7078c7a5649']

--- a/translations/es.php
+++ b/translations/es.php
@@ -2,52 +2,101 @@
 
 global $_MODULE;
 $_MODULE = array();
-$_MODULE['<{blockonomics}prestashop>blockonomics_2cd248faec609d132624980e19c7ca97'] = 'Bitcoin - Blockonomics';
-$_MODULE['<{blockonomics}prestashop>blockonomics_c0de713a1b5c4354ebbd1e2227ce971b'] = 'Módulo para aceptar pagos con bitcoin';
-$_MODULE['<{blockonomics}prestashop>blockonomics_876f23178c29dc2552c0b48bf23cd9bd'] = '¿Está seguro de que quiere desinstalar?';
-$_MODULE['<{blockonomics}prestashop>blockonomics_2f14ecdf24da27a9fb0ded962aa17e8c'] = 'Especifique una clave de API';
-$_MODULE['<{blockonomics}prestashop>blockonomics_575792812af3733426415dc226913037'] = 'Pagar con bitcoin';
-$_MODULE['<{blockonomics}prestashop>blockonomics_db84ee92e4da32563f91afe070e37a7e'] = 'Su servidor está bloqueando las llamadas HTTPS salientes';
-$_MODULE['<{blockonomics}prestashop>blockonomics_71d736bf8acac6f396861493102750d1'] = 'La clave de API es incorrecta';
-$_MODULE['<{blockonomics}prestashop>blockonomics_baa8441e3dbb790354e36e17e77d960a'] = 'Agregue una nueva tienda en el sitio web de blockonomics';
-$_MODULE['<{blockonomics}prestashop>blockonomics_98c2637920a4f98d40f7f6b0fc2fd378'] = 'Para obtener más información, consulte';
-$_MODULE['<{blockonomics}prestashop>blockonomics_c3d515262545a5bde7c683f68afe06f9'] = 'este artículo de resolución de problemas';
-$_MODULE['<{blockonomics}prestashop>blockonomics_f75cbf4937d2f1f31e6a4c727ebfee7b'] = 'Para obtener más información, consulte este artículo de resolución de problemas.';
-$_MODULE['<{blockonomics}prestashop>blockonomics_e576911d3083c76abba01c8a03842856'] = 'Configuración guardada, haga clic en Probar Configuración para verificar la instalación';
-$_MODULE['<{blockonomics}prestashop>blockonomics_f4f70727dc34561dfde1a3c529b6205c'] = 'Configuración';
-$_MODULE['<{blockonomics}prestashop>blockonomics_d876ff8da67c3731ae25d8335a4168b4'] = 'Clave de API';
-$_MODULE['<{blockonomics}prestashop>blockonomics_4090c73f435e12febebe689cdf79031e'] = 'URL DE LLAMADA HTTP';
-$_MODULE['<{blockonomics}prestashop>blockonomics_ff64c6d108f9d4760aaf521fbbabbe8f'] = 'Período de Tiempo';
-$_MODULE['<{blockonomics}prestashop>blockonomics_1d916369325e045bba284bcbce35ccaf'] = 'Temporizador de cuenta regresiva en la página de pago';
-$_MODULE['<{blockonomics}prestashop>blockonomics_70abb32fcb0c9e8194526d1eef15eb05'] = '10 minutos';
-$_MODULE['<{blockonomics}prestashop>blockonomics_2a7bb67d9681d8b5c8241cd49c734772'] = '15 minutos';
-$_MODULE['<{blockonomics}prestashop>blockonomics_f31f3ebbdee89a50923676a58da95904'] = '20 minutos';
-$_MODULE['<{blockonomics}prestashop>blockonomics_92f08914683ec10736d27ad9a15fa624'] = '25 minutos';
-$_MODULE['<{blockonomics}prestashop>blockonomics_0d714869027c4e08ea9b2943d9bd704e'] = '30 minutos';
-$_MODULE['<{blockonomics}prestashop>blockonomics_c9cc8cce247e49bae79f15173ce97354'] = 'Guardar';
-$_MODULE['<{blockonomics}prestashop>blockonomics_a17379a9752f2e6eef6c319c771f5f44'] = 'Para configurar, clicar';
-$_MODULE['<{blockonomics}prestashop>blockonomics_64f676ae6e961fa1e596eeeeef5c7df9'] = 'en Comenzar gratis';
-$_MODULE['<{blockonomics}prestashop>blockonomics_ed2b5c0139cec8ad2873829dc1117d50'] = 'en';
-$_MODULE['<{blockonomics}prestashop>blockonomics_dfcfc43722eef1eab1e4a12e50a068b1'] = 'Divisas';
-$_MODULE['<{blockonomics}prestashop>blockonomics_bfacb577033fa77ff21438e5ff80ca3b'] = 'Bitcoin (BTC)';
-$_MODULE['<{blockonomics}prestashop>blockonomics_9cb7ca5565d6c28ff385f66a173c86a7'] = 'Bitcoin Cash (BCH)';
-$_MODULE['<{blockonomics}prestashop>blockonomics_b279be2ec798cea1e5019824662e53e9'] = 'Probar Configuración';
-$_MODULE['<{blockonomics}prestashop>payment_d1228f5476d15142b1358ae4b5fa2454'] = 'Número de pedido';
-$_MODULE['<{blockonomics}prestashop>payment_8fd2d4cb88dd67be9d343d3398ca763d'] = 'Pago vencido';
-$_MODULE['<{blockonomics}prestashop>payment_79d7ff78f59371847aa73f232be2d196'] = 'Haga clic aquí para volver a intentarlo';
-$_MODULE['<{blockonomics}prestashop>payment_9e553ea6221b688a01e329cf76dde4bf'] = 'El monto de BTC del pedido pagado es menor de lo esperado. Póngase en contacto con el vendedor';
-$_MODULE['<{blockonomics}prestashop>payment_a217a4286be5ab0bd03a98d33a78c420'] = 'Abrir en cartera';
-$_MODULE['<{blockonomics}prestashop>payment_4972448661ca72aa783da607f9b3ecc7'] = 'Para pagar, envíe exactamente';
-$_MODULE['<{blockonomics}prestashop>payment_efc1a46f7b47e4d3cf60f13b6c89069b'] = 'Copiado al portapapeles';
-$_MODULE['<{blockonomics}prestashop>payment_b187de06406775bc913d0c12c6a5dbe6'] = 'A esta';
-$_MODULE['<{blockonomics}prestashop>payment_ea08ae01e95bb85ba4d51f7fa224a956'] = 'dirección';
-$_MODULE['<{blockonomics}prestashop>payment_df9e1aa4940f7a34263d65ef41b87cf1'] = 'min';
-$_MODULE['<{blockonomics}prestashop>payment_7f0801830c4f3ed63e81fc0053177394'] = '¿Cómo realizo el pago? | Consultar reseñas de esta tienda';
-$_MODULE['<{blockonomics}prestashop>payment_69616e342259a7da05c26802caf4f0ea'] = 'Desarrollado por Blockonomics';
-$_MODULE['<{blockonomics}prestashop>no_crypto_7a686f1321744105bd4183854107d431'] = 'Ninguna criptomoneda está habilitada para el pago';
-$_MODULE['<{blockonomics}prestashop>no_crypto_6387ce01d8a5c7eff4bfc2e74afc1767'] = 'Nota para el webmaster: se puede habilitar a través de PrestaShop Admin > Módulos > Administrador de módulos > Bitcoin - Blockonomics > Monedas ';
-$_MODULE['<{blockonomics}prestashop>select_03a7faed722f23ed1f61d3a49425200b'] = 'Pagar con';
-$_MODULE['<{blockonomics}prestashop>validation_02cb6e7914265feb537fe7078c7a5649'] = 'Falta la extensión PHP.';
-$_MODULE['<{blockonomics}prestashop>validation_5dbacc8b4262eb20aa2ec42ab2a1ac0b'] = 'Instale la extensión php-intl que falta';
-$_MODULE['<{blockonomics}prestashop>payment_eb60ab14749e5732652e66fbaf2bd75e'] = 'No se puede generar la dirección de bitcoin.';
-$_MODULE['<{blockonomics}prestashop>payment_b5511b23e304849b337641e03b9223de'] = 'Utilizar el botón Probar Configuración en la configuración para diagnosticar el error';
+$_MODULE['<{blockonomics}prestashop>blockonomics_2cd248faec609d132624980e19c7ca97']
+    = 'Bitcoin - Blockonomics';
+$_MODULE['<{blockonomics}prestashop>blockonomics_c0de713a1b5c4354ebbd1e2227ce971b']
+    = 'Módulo para aceptar pagos con bitcoin';
+$_MODULE['<{blockonomics}prestashop>blockonomics_876f23178c29dc2552c0b48bf23cd9bd']
+    = '¿Está seguro de que quiere desinstalar?';
+$_MODULE['<{blockonomics}prestashop>blockonomics_2f14ecdf24da27a9fb0ded962aa17e8c']
+    = 'Especifique una clave de API';
+$_MODULE['<{blockonomics}prestashop>blockonomics_575792812af3733426415dc226913037']
+    = 'Pagar con bitcoin';
+$_MODULE['<{blockonomics}prestashop>blockonomics_db84ee92e4da32563f91afe070e37a7e']
+    = 'Su servidor está bloqueando las llamadas HTTPS salientes';
+$_MODULE['<{blockonomics}prestashop>blockonomics_71d736bf8acac6f396861493102750d1']
+    = 'La clave de API es incorrecta';
+$_MODULE['<{blockonomics}prestashop>blockonomics_baa8441e3dbb790354e36e17e77d960a']
+    = 'Agregue una nueva tienda en el sitio web de blockonomics';
+$_MODULE['<{blockonomics}prestashop>blockonomics_98c2637920a4f98d40f7f6b0fc2fd378']
+    = 'Para obtener más información, consulte';
+$_MODULE['<{blockonomics}prestashop>blockonomics_c3d515262545a5bde7c683f68afe06f9']
+    = 'este artículo de resolución de problemas';
+$_MODULE['<{blockonomics}prestashop>blockonomics_f75cbf4937d2f1f31e6a4c727ebfee7b']
+    = 'Para obtener más información, consulte este artículo de resolución de problemas.';
+$_MODULE['<{blockonomics}prestashop>blockonomics_e576911d3083c76abba01c8a03842856']
+    = 'Configuración guardada, haga clic en Probar Configuración para verificar la instalación';
+$_MODULE['<{blockonomics}prestashop>blockonomics_f4f70727dc34561dfde1a3c529b6205c']
+    = 'Configuración';
+$_MODULE['<{blockonomics}prestashop>blockonomics_d876ff8da67c3731ae25d8335a4168b4']
+    = 'Clave de API';
+$_MODULE['<{blockonomics}prestashop>blockonomics_4090c73f435e12febebe689cdf79031e']
+    = 'URL DE LLAMADA HTTP';
+$_MODULE['<{blockonomics}prestashop>blockonomics_ff64c6d108f9d4760aaf521fbbabbe8f']
+    = 'Período de Tiempo';
+$_MODULE['<{blockonomics}prestashop>blockonomics_1d916369325e045bba284bcbce35ccaf']
+    = 'Temporizador de cuenta regresiva en la página de pago';
+$_MODULE['<{blockonomics}prestashop>blockonomics_70abb32fcb0c9e8194526d1eef15eb05']
+    = '10 minutos';
+$_MODULE['<{blockonomics}prestashop>blockonomics_2a7bb67d9681d8b5c8241cd49c734772']
+    = '15 minutos';
+$_MODULE['<{blockonomics}prestashop>blockonomics_f31f3ebbdee89a50923676a58da95904']
+    = '20 minutos';
+$_MODULE['<{blockonomics}prestashop>blockonomics_92f08914683ec10736d27ad9a15fa624']
+    = '25 minutos';
+$_MODULE['<{blockonomics}prestashop>blockonomics_0d714869027c4e08ea9b2943d9bd704e']
+    = '30 minutos';
+$_MODULE['<{blockonomics}prestashop>blockonomics_c9cc8cce247e49bae79f15173ce97354']
+    = 'Guardar';
+$_MODULE['<{blockonomics}prestashop>blockonomics_a17379a9752f2e6eef6c319c771f5f44']
+    = 'Para configurar, clicar';
+$_MODULE['<{blockonomics}prestashop>blockonomics_64f676ae6e961fa1e596eeeeef5c7df9']
+    = 'en Comenzar gratis';
+$_MODULE['<{blockonomics}prestashop>blockonomics_ed2b5c0139cec8ad2873829dc1117d50']
+    = 'en';
+$_MODULE['<{blockonomics}prestashop>blockonomics_dfcfc43722eef1eab1e4a12e50a068b1']
+    = 'Divisas';
+$_MODULE['<{blockonomics}prestashop>blockonomics_bfacb577033fa77ff21438e5ff80ca3b']
+    = 'Bitcoin (BTC)';
+$_MODULE['<{blockonomics}prestashop>blockonomics_9cb7ca5565d6c28ff385f66a173c86a7']
+    = 'Bitcoin Cash (BCH)';
+$_MODULE['<{blockonomics}prestashop>blockonomics_b279be2ec798cea1e5019824662e53e9']
+    = 'Probar Configuración';
+$_MODULE['<{blockonomics}prestashop>payment_d1228f5476d15142b1358ae4b5fa2454']
+    = 'Número de pedido';
+$_MODULE['<{blockonomics}prestashop>payment_8fd2d4cb88dd67be9d343d3398ca763d']
+    = 'Pago vencido';
+$_MODULE['<{blockonomics}prestashop>payment_79d7ff78f59371847aa73f232be2d196']
+    = 'Haga clic aquí para volver a intentarlo';
+$_MODULE['<{blockonomics}prestashop>payment_9e553ea6221b688a01e329cf76dde4bf']
+    = 'El monto de BTC del pedido pagado es menor de lo esperado. Póngase en contacto con el vendedor';
+$_MODULE['<{blockonomics}prestashop>payment_a217a4286be5ab0bd03a98d33a78c420']
+    = 'Abrir en cartera';
+$_MODULE['<{blockonomics}prestashop>payment_4972448661ca72aa783da607f9b3ecc7']
+    = 'Para pagar, envíe exactamente';
+$_MODULE['<{blockonomics}prestashop>payment_efc1a46f7b47e4d3cf60f13b6c89069b']
+    = 'Copiado al portapapeles';
+$_MODULE['<{blockonomics}prestashop>payment_b187de06406775bc913d0c12c6a5dbe6']
+    = 'A esta';
+$_MODULE['<{blockonomics}prestashop>payment_ea08ae01e95bb85ba4d51f7fa224a956']
+    = 'dirección';
+$_MODULE['<{blockonomics}prestashop>payment_df9e1aa4940f7a34263d65ef41b87cf1']
+    = 'min';
+$_MODULE['<{blockonomics}prestashop>payment_7f0801830c4f3ed63e81fc0053177394']
+    = '¿Cómo realizo el pago? | Consultar reseñas de esta tienda';
+$_MODULE['<{blockonomics}prestashop>payment_69616e342259a7da05c26802caf4f0ea']
+    = 'Desarrollado por Blockonomics';
+$_MODULE['<{blockonomics}prestashop>no_crypto_7a686f1321744105bd4183854107d431']
+    = 'Ninguna criptomoneda está habilitada para el pago';
+$_MODULE['<{blockonomics}prestashop>no_crypto_6387ce01d8a5c7eff4bfc2e74afc1767']
+    = 'Nota para el webmaster: se puede habilitar a través de PrestaShop Admin > Módulos > Administrador de módulos > Bitcoin - Blockonomics > Monedas ';
+$_MODULE['<{blockonomics}prestashop>select_03a7faed722f23ed1f61d3a49425200b']
+    = 'Pagar con';
+$_MODULE['<{blockonomics}prestashop>validation_02cb6e7914265feb537fe7078c7a5649']
+    = 'Falta la extensión PHP.';
+$_MODULE['<{blockonomics}prestashop>validation_5dbacc8b4262eb20aa2ec42ab2a1ac0b']
+    = 'Instale la extensión php-intl que falta';
+$_MODULE['<{blockonomics}prestashop>payment_eb60ab14749e5732652e66fbaf2bd75e']
+    = 'No se puede generar la dirección de bitcoin.';
+$_MODULE['<{blockonomics}prestashop>payment_b5511b23e304849b337641e03b9223de']
+    = 'Utilizar el botón Probar Configuración en la configuración para diagnosticar el error';

--- a/translations/fr.php
+++ b/translations/fr.php
@@ -2,52 +2,101 @@
 
 global $_MODULE;
 $_MODULE = array();
-$_MODULE['<{blockonomics}prestashop>blockonomics_2cd248faec609d132624980e19c7ca97'] = 'Bitcoin - Blockonomics';
-$_MODULE['<{blockonomics}prestashop>blockonomics_c0de713a1b5c4354ebbd1e2227ce971b'] = 'Module de paiement par Bitcoin';
-$_MODULE['<{blockonomics}prestashop>blockonomics_876f23178c29dc2552c0b48bf23cd9bd'] = 'Êtes-vous sûr de vouloir désinstaller le module ?';
-$_MODULE['<{blockonomics}prestashop>blockonomics_2f14ecdf24da27a9fb0ded962aa17e8c'] = 'Veuillez entrer une clé API';
-$_MODULE['<{blockonomics}prestashop>blockonomics_575792812af3733426415dc226913037'] = 'Payer avec Bitcoin';
-$_MODULE['<{blockonomics}prestashop>blockonomics_db84ee92e4da32563f91afe070e37a7e'] = 'Votre serveur bloque les appels HTTPS sortants';
-$_MODULE['<{blockonomics}prestashop>blockonomics_71d736bf8acac6f396861493102750d1'] = 'La clé API est incorrecte';
-$_MODULE['<{blockonomics}prestashop>blockonomics_baa8441e3dbb790354e36e17e77d960a'] = 'Veuillez ajouter un nouveau magasin sur le site Web de blockonomics';
-$_MODULE['<{blockonomics}prestashop>blockonomics_98c2637920a4f98d40f7f6b0fc2fd378'] = 'Pour plus d\'informations, veuillez consulter ce ';
-$_MODULE['<{blockonomics}prestashop>blockonomics_c3d515262545a5bde7c683f68afe06f9'] = 'guide de dépannage';
-$_MODULE['<{blockonomics}prestashop>blockonomics_f75cbf4937d2f1f31e6a4c727ebfee7b'] = 'La configuration est terminée !';
-$_MODULE['<{blockonomics}prestashop>blockonomics_e576911d3083c76abba01c8a03842856'] = 'Paramètres enregistrés. Cliquez sur Tester la configuration pour vérifier l\'installation.';
-$_MODULE['<{blockonomics}prestashop>blockonomics_f4f70727dc34561dfde1a3c529b6205c'] = 'Paramètres';
-$_MODULE['<{blockonomics}prestashop>blockonomics_d876ff8da67c3731ae25d8335a4168b4'] = 'Clé API';
-$_MODULE['<{blockonomics}prestashop>blockonomics_4090c73f435e12febebe689cdf79031e'] = 'URL DE RAPPEL HTTP';
-$_MODULE['<{blockonomics}prestashop>blockonomics_ff64c6d108f9d4760aaf521fbbabbe8f'] = 'Durée';
-$_MODULE['<{blockonomics}prestashop>blockonomics_1d916369325e045bba284bcbce35ccaf'] = 'Compte à rebours sur la page de paiement';
-$_MODULE['<{blockonomics}prestashop>blockonomics_70abb32fcb0c9e8194526d1eef15eb05'] = '10 minutes';
-$_MODULE['<{blockonomics}prestashop>blockonomics_2a7bb67d9681d8b5c8241cd49c734772'] = '15 minutes';
-$_MODULE['<{blockonomics}prestashop>blockonomics_f31f3ebbdee89a50923676a58da95904'] = '20 minutes';
-$_MODULE['<{blockonomics}prestashop>blockonomics_92f08914683ec10736d27ad9a15fa624'] = '25 minutes';
-$_MODULE['<{blockonomics}prestashop>blockonomics_0d714869027c4e08ea9b2943d9bd704e'] = '30 minutes';
-$_MODULE['<{blockonomics}prestashop>blockonomics_c9cc8cce247e49bae79f15173ce97354'] = 'Enregistrer';
-$_MODULE['<{blockonomics}prestashop>blockonomics_a17379a9752f2e6eef6c319c771f5f44'] = 'Pour configurer, cliquez ';
-$_MODULE['<{blockonomics}prestashop>blockonomics_64f676ae6e961fa1e596eeeeef5c7df9'] = 'sur Démarrer gratuitement';
-$_MODULE['<{blockonomics}prestashop>blockonomics_ed2b5c0139cec8ad2873829dc1117d50'] = 'le';
-$_MODULE['<{blockonomics}prestashop>blockonomics_dfcfc43722eef1eab1e4a12e50a068b1'] = 'Monnaies';
-$_MODULE['<{blockonomics}prestashop>blockonomics_bfacb577033fa77ff21438e5ff80ca3b'] = 'Bitcoin (BTC)';
-$_MODULE['<{blockonomics}prestashop>blockonomics_9cb7ca5565d6c28ff385f66a173c86a7'] = 'Bitcoin Cash (BCH)';
-$_MODULE['<{blockonomics}prestashop>blockonomics_b279be2ec798cea1e5019824662e53e9'] = 'Tester la configuration';
-$_MODULE['<{blockonomics}prestashop>payment_d1228f5476d15142b1358ae4b5fa2454'] = 'N° de commande';
-$_MODULE['<{blockonomics}prestashop>payment_8fd2d4cb88dd67be9d343d3398ca763d'] = 'Paiement expiré';
-$_MODULE['<{blockonomics}prestashop>payment_79d7ff78f59371847aa73f232be2d196'] = 'Cliquez ici pour réessayer';
-$_MODULE['<{blockonomics}prestashop>payment_9e553ea6221b688a01e329cf76dde4bf'] = 'Le montant de la commande payé en BTC est inférieur au montant attendu. Contacter le marchand';
-$_MODULE['<{blockonomics}prestashop>payment_a217a4286be5ab0bd03a98d33a78c420'] = 'Ouvrir dans le portefeuille';
-$_MODULE['<{blockonomics}prestashop>payment_4972448661ca72aa783da607f9b3ecc7'] = 'Pour effectuer le paiement, envoyer exactement';
-$_MODULE['<{blockonomics}prestashop>payment_efc1a46f7b47e4d3cf60f13b6c89069b'] = 'Copié dans le presse-papier';
-$_MODULE['<{blockonomics}prestashop>payment_b187de06406775bc913d0c12c6a5dbe6'] = 'À cette';
-$_MODULE['<{blockonomics}prestashop>payment_ea08ae01e95bb85ba4d51f7fa224a956'] = 'adresse';
-$_MODULE['<{blockonomics}prestashop>payment_df9e1aa4940f7a34263d65ef41b87cf1'] = 'min';
-$_MODULE['<{blockonomics}prestashop>payment_7f0801830c4f3ed63e81fc0053177394'] = 'Comment payer ? | Consulter les avis sur cette boutique';
-$_MODULE['<{blockonomics}prestashop>payment_69616e342259a7da05c26802caf4f0ea'] = 'Proposé par Blockonomics';
-$_MODULE['<{blockonomics}prestashop>no_crypto_7a686f1321744105bd4183854107d431'] = 'Aucune crypto-monnaie n\'est activée pour les paiements';
-$_MODULE['<{blockonomics}prestashop>no_crypto_6387ce01d8a5c7eff4bfc2e74afc1767'] = 'Note à l\'administrateur : Peut être activée via Administrateur PrestaShop > Modules > Gestionnaire de modules > Bitcoin - Blockonomics > Monnaies';
-$_MODULE['<{blockonomics}prestashop>select_03a7faed722f23ed1f61d3a49425200b'] = 'Pay avec';
-$_MODULE['<{blockonomics}prestashop>validation_02cb6e7914265feb537fe7078c7a5649'] = 'Extension PHP absente.';
-$_MODULE['<{blockonomics}prestashop>validation_5dbacc8b4262eb20aa2ec42ab2a1ac0b'] = 'Veuillez installer l\'extension php-intl manquante';
-$_MODULE['<{blockonomics}prestashop>payment_eb60ab14749e5732652e66fbaf2bd75e'] = 'Impossible de générer une adresse bitcoin.';
-$_MODULE['<{blockonomics}prestashop>payment_b5511b23e304849b337641e03b9223de'] = 'Veuillez utiliser le bouton Tester la configuration pour diagnostiquer l\'erreur';
+$_MODULE['<{blockonomics}prestashop>blockonomics_2cd248faec609d132624980e19c7ca97']
+    = 'Bitcoin - Blockonomics';
+$_MODULE['<{blockonomics}prestashop>blockonomics_c0de713a1b5c4354ebbd1e2227ce971b']
+    = 'Module de paiement par Bitcoin';
+$_MODULE['<{blockonomics}prestashop>blockonomics_876f23178c29dc2552c0b48bf23cd9bd']
+    = 'Êtes-vous sûr de vouloir désinstaller le module ?';
+$_MODULE['<{blockonomics}prestashop>blockonomics_2f14ecdf24da27a9fb0ded962aa17e8c']
+    = 'Veuillez entrer une clé API';
+$_MODULE['<{blockonomics}prestashop>blockonomics_575792812af3733426415dc226913037']
+    = 'Payer avec Bitcoin';
+$_MODULE['<{blockonomics}prestashop>blockonomics_db84ee92e4da32563f91afe070e37a7e']
+    = 'Votre serveur bloque les appels HTTPS sortants';
+$_MODULE['<{blockonomics}prestashop>blockonomics_71d736bf8acac6f396861493102750d1']
+    = 'La clé API est incorrecte';
+$_MODULE['<{blockonomics}prestashop>blockonomics_baa8441e3dbb790354e36e17e77d960a']
+    = 'Veuillez ajouter un nouveau magasin sur le site Web de blockonomics';
+$_MODULE['<{blockonomics}prestashop>blockonomics_98c2637920a4f98d40f7f6b0fc2fd378']
+    = 'Pour plus d\'informations, veuillez consulter ce ';
+$_MODULE['<{blockonomics}prestashop>blockonomics_c3d515262545a5bde7c683f68afe06f9']
+    = 'guide de dépannage';
+$_MODULE['<{blockonomics}prestashop>blockonomics_f75cbf4937d2f1f31e6a4c727ebfee7b']
+    = 'La configuration est terminée !';
+$_MODULE['<{blockonomics}prestashop>blockonomics_e576911d3083c76abba01c8a03842856']
+    = 'Paramètres enregistrés. Cliquez sur Tester la configuration pour vérifier l\'installation.';
+$_MODULE['<{blockonomics}prestashop>blockonomics_f4f70727dc34561dfde1a3c529b6205c']
+    = 'Paramètres';
+$_MODULE['<{blockonomics}prestashop>blockonomics_d876ff8da67c3731ae25d8335a4168b4']
+    = 'Clé API';
+$_MODULE['<{blockonomics}prestashop>blockonomics_4090c73f435e12febebe689cdf79031e']
+    = 'URL DE RAPPEL HTTP';
+$_MODULE['<{blockonomics}prestashop>blockonomics_ff64c6d108f9d4760aaf521fbbabbe8f']
+    = 'Durée';
+$_MODULE['<{blockonomics}prestashop>blockonomics_1d916369325e045bba284bcbce35ccaf']
+    = 'Compte à rebours sur la page de paiement';
+$_MODULE['<{blockonomics}prestashop>blockonomics_70abb32fcb0c9e8194526d1eef15eb05']
+    = '10 minutes';
+$_MODULE['<{blockonomics}prestashop>blockonomics_2a7bb67d9681d8b5c8241cd49c734772']
+    = '15 minutes';
+$_MODULE['<{blockonomics}prestashop>blockonomics_f31f3ebbdee89a50923676a58da95904']
+    = '20 minutes';
+$_MODULE['<{blockonomics}prestashop>blockonomics_92f08914683ec10736d27ad9a15fa624']
+    = '25 minutes';
+$_MODULE['<{blockonomics}prestashop>blockonomics_0d714869027c4e08ea9b2943d9bd704e']
+    = '30 minutes';
+$_MODULE['<{blockonomics}prestashop>blockonomics_c9cc8cce247e49bae79f15173ce97354']
+    = 'Enregistrer';
+$_MODULE['<{blockonomics}prestashop>blockonomics_a17379a9752f2e6eef6c319c771f5f44']
+    = 'Pour configurer, cliquez ';
+$_MODULE['<{blockonomics}prestashop>blockonomics_64f676ae6e961fa1e596eeeeef5c7df9']
+    = 'sur Démarrer gratuitement';
+$_MODULE['<{blockonomics}prestashop>blockonomics_ed2b5c0139cec8ad2873829dc1117d50']
+    = 'le';
+$_MODULE['<{blockonomics}prestashop>blockonomics_dfcfc43722eef1eab1e4a12e50a068b1']
+    = 'Monnaies';
+$_MODULE['<{blockonomics}prestashop>blockonomics_bfacb577033fa77ff21438e5ff80ca3b']
+    = 'Bitcoin (BTC)';
+$_MODULE['<{blockonomics}prestashop>blockonomics_9cb7ca5565d6c28ff385f66a173c86a7']
+    = 'Bitcoin Cash (BCH)';
+$_MODULE['<{blockonomics}prestashop>blockonomics_b279be2ec798cea1e5019824662e53e9']
+    = 'Tester la configuration';
+$_MODULE['<{blockonomics}prestashop>payment_d1228f5476d15142b1358ae4b5fa2454']
+    = 'N° de commande';
+$_MODULE['<{blockonomics}prestashop>payment_8fd2d4cb88dd67be9d343d3398ca763d']
+    = 'Paiement expiré';
+$_MODULE['<{blockonomics}prestashop>payment_79d7ff78f59371847aa73f232be2d196']
+    = 'Cliquez ici pour réessayer';
+$_MODULE['<{blockonomics}prestashop>payment_9e553ea6221b688a01e329cf76dde4bf']
+    = 'Le montant de la commande payé en BTC est inférieur au montant attendu. Contacter le marchand';
+$_MODULE['<{blockonomics}prestashop>payment_a217a4286be5ab0bd03a98d33a78c420']
+    = 'Ouvrir dans le portefeuille';
+$_MODULE['<{blockonomics}prestashop>payment_4972448661ca72aa783da607f9b3ecc7']
+    = 'Pour effectuer le paiement, envoyer exactement';
+$_MODULE['<{blockonomics}prestashop>payment_efc1a46f7b47e4d3cf60f13b6c89069b']
+    = 'Copié dans le presse-papier';
+$_MODULE['<{blockonomics}prestashop>payment_b187de06406775bc913d0c12c6a5dbe6']
+    = 'À cette';
+$_MODULE['<{blockonomics}prestashop>payment_ea08ae01e95bb85ba4d51f7fa224a956']
+    = 'adresse';
+$_MODULE['<{blockonomics}prestashop>payment_df9e1aa4940f7a34263d65ef41b87cf1']
+    = 'min';
+$_MODULE['<{blockonomics}prestashop>payment_7f0801830c4f3ed63e81fc0053177394']
+    = 'Comment payer ? | Consulter les avis sur cette boutique';
+$_MODULE['<{blockonomics}prestashop>payment_69616e342259a7da05c26802caf4f0ea']
+    = 'Proposé par Blockonomics';
+$_MODULE['<{blockonomics}prestashop>no_crypto_7a686f1321744105bd4183854107d431']
+    = 'Aucune crypto-monnaie n\'est activée pour les paiements';
+$_MODULE['<{blockonomics}prestashop>no_crypto_6387ce01d8a5c7eff4bfc2e74afc1767']
+    = 'Note à l\'administrateur : Peut être activée via Administrateur PrestaShop > Modules > Gestionnaire de modules > Bitcoin - Blockonomics > Monnaies';
+$_MODULE['<{blockonomics}prestashop>select_03a7faed722f23ed1f61d3a49425200b']
+    = 'Pay avec';
+$_MODULE['<{blockonomics}prestashop>validation_02cb6e7914265feb537fe7078c7a5649']
+    = 'Extension PHP absente.';
+$_MODULE['<{blockonomics}prestashop>validation_5dbacc8b4262eb20aa2ec42ab2a1ac0b']
+    = 'Veuillez installer l\'extension php-intl manquante';
+$_MODULE['<{blockonomics}prestashop>payment_eb60ab14749e5732652e66fbaf2bd75e']
+    = 'Impossible de générer une adresse bitcoin.';
+$_MODULE['<{blockonomics}prestashop>payment_b5511b23e304849b337641e03b9223de']
+    = 'Veuillez utiliser le bouton Tester la configuration pour diagnostiquer l\'erreur';

--- a/translations/fr.php
+++ b/translations/fr.php
@@ -89,7 +89,8 @@ $_MODULE['<{blockonomics}prestashop>payment_69616e342259a7da05c26802caf4f0ea']
 $_MODULE['<{blockonomics}prestashop>no_crypto_7a686f1321744105bd4183854107d431']
     = 'Aucune crypto-monnaie n\'est activée pour les paiements';
 $_MODULE['<{blockonomics}prestashop>no_crypto_6387ce01d8a5c7eff4bfc2e74afc1767']
-    = 'Note à l\'administrateur : Peut être activée via Administrateur PrestaShop > Modules > Gestionnaire de modules > Bitcoin - Blockonomics > Monnaies';
+    = 'Note à l\'administrateur : Peut être activée via '.
+        'Administrateur PrestaShop > Modules > Gestionnaire de modules > Bitcoin - Blockonomics > Monnaies';
 $_MODULE['<{blockonomics}prestashop>select_03a7faed722f23ed1f61d3a49425200b']
     = 'Pay avec';
 $_MODULE['<{blockonomics}prestashop>validation_02cb6e7914265feb537fe7078c7a5649']

--- a/views/templates/front/no_crypto.tpl
+++ b/views/templates/front/no_crypto.tpl
@@ -1,5 +1,5 @@
 {*
- * 2011-2021 Blockonomics
+ * 2011-2022 Blockonomics
  *
  * NOTICE OF LICENSE
  *
@@ -12,7 +12,7 @@
  * to license@blockonomics.co so we can send you a copy immediately.
  *
  * @author    Blockonomics Admin <admin@blockonomics.co>
- * @copyright 2011-2021 Blockonomics
+ * @copyright 2011-2022 Blockonomics
  * @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
  * International Registered Trademark & Property of Blockonomics
  *}

--- a/views/templates/hook/logo_height.tpl
+++ b/views/templates/hook/logo_height.tpl
@@ -12,7 +12,7 @@
  * to license@blockonomics.co so we can send you a copy immediately.
  *
  * @author    Blockonomics Admin <admin@blockonomics.co>
- * @copyright 2011-2021 Blockonomics
+ * @copyright 2011-2022 Blockonomics
  * @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
  * International Registered Trademark & Property of Blockonomics
  *}


### PR DESCRIPTION
Currently the Prestashop Module Validator is giving some warnings under 'Licenses' & 'Standards' :

![image](https://user-images.githubusercontent.com/97018228/180129113-75291ff1-94ea-4af2-b0f4-af8f77e85a4a.png)

- Licenses: License headers are not up to date
- Standards: Making coding norms inline with Prestashop's standard.

## Fixed:
- Licenses:
<img width="897" alt="image" src="https://user-images.githubusercontent.com/97018228/180132868-5495ed93-06f5-4383-8244-1aee69d0ad63.png">

- Standards:
<img width="872" alt="image" src="https://user-images.githubusercontent.com/97018228/180140253-42cfdd56-d2e3-4d6d-b4b9-0f763ec13171.png">


