### PR TITLE
Fix checkout for v8

### DIFF
--- a/blockonomics.php
+++ b/blockonomics.php
@@ -297,7 +297,7 @@ class Blockonomics extends PaymentModule
         curl_close($ch);
 
         $responseObj = new stdClass();
-        $responseObj->data = Tools::jsonDecode($data);
+        $responseObj->data = json_decode($data);
         $responseObj->response_code = $httpcode;
 
         return $responseObj;


### PR DESCRIPTION
Using [`json_decode`](https://www.php.net/manual/en/function.json-decode.php) instead of [deprecated method `Tools::jsonDecode()`](https://devdocs.prestashop-project.org/8/modules/core-updates/8.0/#removed-methods)