### PR TITLE
Resolve installation for PS version > 8.0.1

### DIFF
--- a/blockonomics.php
+++ b/blockonomics.php
@@ -46,7 +46,7 @@ class Blockonomics extends PaymentModule
         $this->bootstrap = true;
         $this->ps_versions_compliancy = [
             'min' => '8.0',
-            'max' => '8.99.99',
+            'max' => _PS_VERSION_,
         ];
         $this->controllers = ['validation'];
         $this->module_key = '454392b952b7d0cfc55a656b3cdebb12';

--- a/blockonomics.php
+++ b/blockonomics.php
@@ -46,7 +46,7 @@ class Blockonomics extends PaymentModule
         $this->bootstrap = true;
         $this->ps_versions_compliancy = [
             'min' => '8.0',
-            'max' => '8.0.1',
+            'max' => '8.99.99',
         ];
         $this->controllers = ['validation'];
         $this->module_key = '454392b952b7d0cfc55a656b3cdebb12';


### PR DESCRIPTION
This PR aims to fix #160 

---
Changes done -
in `blockonomics.php` , Changing the ps_versions_compliancy array from
`$this->ps_versions_compliancy = [ 'min' => '8.0', 'max' => '8.0.1',]`;
to
`$this->ps_versions_compliancy = [ 'min' => '8.0', 'max' => _PS_VERSION_,];`

Note that this is similar to our plugin for [PS version 1.7](https://github.com/blockonomics/prestashop-plugin/blob/1.7/blockonomics.php#L50).

---

PS Validator Results:
Validator is passing all except compatibility which seems to be related to this array. However, Compatibility tab is unclickable so we can not be sure and report is also not downloading as PS Validator throws 5XX error.

![image](https://github.com/blockonomics/prestashop-plugin/assets/97018228/6946a464-028b-4365-a40c-4b0432bd2e95)
